### PR TITLE
fix plexapi default timeout

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # standard imports
+import os
 import re
 import sys
 
@@ -30,10 +31,8 @@ import youtube_dl
 # local imports
 if sys.version_info.major < 3:
     from default_prefs import default_prefs
-    from plex_api_helper import add_themes
 else:
     from .default_prefs import default_prefs
-    from .plex_api_helper import add_themes
 
 
 def process_youtube(url):
@@ -90,6 +89,26 @@ def process_youtube(url):
     return audio_url  # return None or url found
 
 
+def set_environment(key, value):
+    # type: (str, str) -> None
+    """
+    Set an environment variable key to a specified value.
+
+    Parameters
+    ----------
+    key : str
+       The variable name.
+    value : str
+        The variable value.
+
+    Examples
+    --------
+    >>> set_environment(key='plexapi_plexapi_timeout', value='180')
+    ...
+    """
+    os.environ[key.upper()] = value
+
+
 def ValidatePrefs():
     # type: () -> MessageContainer
     """
@@ -133,6 +152,10 @@ def ValidatePrefs():
                 if Prefs[key] is not True and Prefs[key] is not False:
                     Log.Error("Setting '%s' must be True or False; Value '%s'" % (key, Prefs[key]))
                     error_message += "Setting '%s' must be True or False; Value '%s'<br/>" % (key, Prefs[key])
+
+            plexapi_key = key.split('_', 1)[-1]
+            if plexapi_key.startswith('plexapi_'):
+                set_environment(key=plexapi_key, value=Prefs[key])
 
     if error_message != '':
         return MessageContainer(header='Error', message=error_message)
@@ -353,6 +376,7 @@ class Themerr(Agent.Movies):
             theme_url = process_youtube(url=yt_video_url)
 
             if theme_url:
+                from plex_api_helper import add_themes  # import here to allow environment variable to be fully setup
                 add_themes(rating_key=rating_key, theme_urls=[theme_url])
 
         return metadata

--- a/Contents/Code/default_prefs.py
+++ b/Contents/Code/default_prefs.py
@@ -1,5 +1,5 @@
 default_prefs = dict(
-    int_upload_timeout='60',
+    int_plexapi_plexapi_timeout='180',
     str_youtube_user='',
     str_youtube_passwd='',
     url_plex_server='http://localhost:32400'

--- a/Contents/Code/plex_api_helper.py
+++ b/Contents/Code/plex_api_helper.py
@@ -13,7 +13,6 @@ else:  # the code is running outside of Plex
 import requests
 from typing import Optional
 import urllib3
-import plexapi
 from plexapi.server import PlexServer
 
 
@@ -34,8 +33,6 @@ def setup_plexapi():
     >>> setup_plexapi()
     ...
     """
-    plexapi.TIMEOUT = int(Prefs['int_upload_timeout'])
-
     plex_url = Prefs['url_plex_server']
     Log.Debug('Plex url: %s' % plex_url)
 

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -1,9 +1,9 @@
 [
 	{
-		"id": "int_upload_timeout",
+		"id": "int_plexapi_plexapi_timeout",
 		"type": "text",
-		"label": "Upload Timeout (in seconds)",
-		"default": "60",
+		"label": "PlexAPI Timeout, in seconds (requires a Plex Media Server restart)",
+		"default": "180",
 		"secure": "false"
 	},
 	{

--- a/docs/source/about/usage.rst
+++ b/docs/source/about/usage.rst
@@ -20,14 +20,14 @@ Minimal setup is required to use Themerr-plex. In addition to the installation, 
 Preferences
 -----------
 
-Upload Timeout
-^^^^^^^^^^^^^^
+PlexAPI Timeout
+^^^^^^^^^^^^^^^
 
 Description
    The timeout (in seconds) when uploading theme audio to the Plex server.
 
 Default
-   ``60``
+   ``180``
 
 YouTube Username
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- fix plexapi default timeout
- set default timeout to 180 seconds (3 minutes)


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
