### PR TITLE
fix `plexapi.utils` import

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,7 @@ jobs:
         id: verify_changelog
         if: ${{ github.ref == 'refs/heads/master' || github.base_ref == 'master' }}
         # base_ref for pull request check, ref for push
-        uses: LizardByte/actions/verify_changelog@master
+        uses: LizardByte/.github/actions/verify_changelog@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
     outputs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.1.1] - 2023-01-19
+### Fixed
+- Fixed `plexapi.utils` import, causing plugin to hang
+
 ## [0.1.0] - 2023-01-18
 ### Added
 - Added support for new Plex Movie agent
@@ -55,3 +59,4 @@
 [0.0.7]: https://github.com/lizardbyte/themerr-plex/releases/tag/v0.0.7
 [0.0.8]: https://github.com/lizardbyte/themerr-plex/releases/tag/v0.0.8
 [0.1.0]: https://github.com/lizardbyte/themerr-plex/releases/tag/v0.1.0
+[0.1.1]: https://github.com/lizardbyte/themerr-plex/releases/tag/v0.1.1

--- a/Contents/Code/plex_api_helper.py
+++ b/Contents/Code/plex_api_helper.py
@@ -19,9 +19,9 @@ import requests
 from typing import Optional
 import urllib3
 from urllib3.exceptions import InsecureRequestWarning
-import plexapi.alert
+from plexapi.alert import AlertListener
 import plexapi.server
-import plexapi.utils
+from plexapi.utils import reverseSearchType
 
 # local imports
 if sys.version_info.major < 3:
@@ -131,7 +131,7 @@ def plex_listener():
     global plex
     if not plex:
         plex = setup_plexapi()
-    listener = plexapi.alert.AlertListener(server=plex, callback=plex_listener_handler, callbackError=Log.Error)
+    listener = AlertListener(server=plex, callback=plex_listener_handler, callbackError=Log.Error)
     listener.run()
 
 
@@ -164,9 +164,9 @@ def plex_listener_handler(data):
 
             # known search types:
             # https://github.com/pkkid/python-plexapi/blob/8b3235445f6b3051c39ff6d6fc5d49f4e674d576/plexapi/utils.py#L35-L55
-            if plexapi.utils.reverseSearchType(libtype=entry['type']) == 'movie' \
-                    and entry['state'] == 5 \
-                    and entry['identifier'] == 'com.plexapp.plugins.library':
+            if (reverseSearchType(libtype=entry['type']) == 'movie'
+                    and entry['state'] == 5
+                    and entry['identifier'] == 'com.plexapp.plugins.library'):
                 # todo - add themes for collections
                 # identifier always appears to be `com.plexapp.plugins.library` for updating library metadata
                 # entry['title'] = movie title

--- a/docs/source/about/troubleshooting.rst
+++ b/docs/source/about/troubleshooting.rst
@@ -1,0 +1,26 @@
+:github_url: https://github.com/LizardByte/Themerr-plex/tree/nightly/docs/source/about/troubleshooting.rst
+
+Troubleshooting
+===============
+
+Plugin Logs
+-----------
+
+See `Plugin Log Files <https://support.plex.tv/articles/201106148-channel-log-files/>`_ for the plugin
+log directory.
+
+Plex uses rolling logs. There will be six log files available. The newest log file will be named
+``dev.lizardbyte.themerr-plex.log``. There will be additional log files with the same name, appended with a `1-5`.
+
+It is best to replicate the issue you are experiencing, then review the latest log file. The information in the log
+file may seem cryptic. If so it would be best to reach out for `support <https://app.lizardbyte.dev/support>`_.
+
+.. Attention:: Before uploading logs, it would be wise to review the data in the log file. Plex does not filter
+   the masked settings (e.g. credentials) out of the log file.
+
+Plex Media Server Logs
+----------------------
+
+If you have a more severe problem, you may need to troubleshoot an issue beyond the plugin itself. See
+`Plex Media Server Logs <https://support.plex.tv/articles/200250417-plex-media-server-log-files/>`_
+for more information.

--- a/docs/source/toc.rst
+++ b/docs/source/toc.rst
@@ -6,6 +6,7 @@
    about/installation
    about/docker
    about/usage
+   about/troubleshooting
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- fix `plexapi.utils` import which caused plugin to hang

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
