### PR TITLE
docker: remove link arg from final copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.1.4] - 2023-02-04
+### Fixed
+- (Docker) Fixed issue where plugin would not load with LinuxServer.io image using a docker mod, introduced in v0.1.0.
+
 ## [0.1.3] - 2023-01-28
 ### Added
 - Max Retries setting added, allowing you to specify how many times to retry a failed upload
@@ -75,3 +79,4 @@
 [0.1.1]: https://github.com/lizardbyte/themerr-plex/releases/tag/v0.1.1
 [0.1.2]: https://github.com/lizardbyte/themerr-plex/releases/tag/v0.1.2
 [0.1.3]: https://github.com/lizardbyte/themerr-plex/releases/tag/v0.1.3
+[0.1.4]: https://github.com/lizardbyte/themerr-plex/releases/tag/v0.1.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,4 +46,6 @@ ARG PLUGIN_NAME="Themerr-plex.bundle"
 ARG PLUGIN_DIR="/config/Library/Application Support/Plex Media Server/Plug-ins"
 
 # add files from buildstage
-COPY --link --from=buildstage /build/ $PLUGIN_DIR/$PLUGIN_NAME
+# trailing slash on build directory copies the contents of the directory, instead of the directory itself
+# do not use `--link` here, the docker mod will not work
+COPY --from=buildstage /build/ $PLUGIN_DIR/$PLUGIN_NAME


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- Removes `--link` arg from final COPY step, which prevents the docker mod from loading the plugin properly.
- Update changelog for v0.1.4.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
