### PR TITLE
build(deps): bump python from 2.7.17-buster to 2.7.18-buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.4
 # artifacts: false
 # platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
-FROM python:2.7.17-buster AS buildstage
+FROM python:2.7.18-buster AS buildstage
 # in order to use ubuntu:22.04 or newer, we will need to install git from source
 
 # build args
@@ -14,7 +14,7 @@ ARG GITHUB_SHA=$COMMIT
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # git 2.34 does not work with python 2.7
 # git 2.25 may work since it is included with ubuntu 20.04
-# too install git from source, see here: https://stackoverflow.com/a/52344030/11214013
+# to install git from source, see here: https://stackoverflow.com/a/52344030/11214013
 # install dependencies
 #RUN <<_DEPS
 ##!/bin/bash


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Use python 2.7.18 instead of 2.7.17. Not sure why @dependabot changed from `2.7-buster` to `2.7.17-buster`...


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
