### PR TITLE
build(docker): move docker image to ubuntu 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 # syntax=docker/dockerfile:1.4
 # artifacts: false
 # platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
-FROM python:2.7.18-buster AS buildstage
-# in order to use ubuntu:22.04 or newer, we will need to install git from source
+FROM ubuntu:22.04 AS buildstage
 
 # build args
 ARG BUILD_VERSION
@@ -12,21 +11,17 @@ ARG GITHUB_SHA=$COMMIT
 # note: build_plist.py uses BUILD_VERSION and GITHUB_SHA
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-# git 2.34 does not work with python 2.7
-# git 2.25 may work since it is included with ubuntu 20.04
-# to install git from source, see here: https://stackoverflow.com/a/52344030/11214013
 # install dependencies
-#RUN <<_DEPS
-##!/bin/bash
-#set -e
-#apt-get update -y
-#apt-get install -y --no-install-recommends \
-#  git=1:2.34.1* \
-#  python2=2.7.18* \
-#  python-pip=20.3.4*
-#apt-get clean
-#rm -rf /var/lib/apt/lists/*
-#_DEPS
+RUN <<_DEPS
+#!/bin/bash
+set -e
+apt-get update -y
+apt-get install -y --no-install-recommends \
+  python2=2.7.18* \
+  python-pip=20.3.4*
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+_DEPS
 
 # create build dir and copy GitHub repo there
 COPY --link . /build
@@ -38,7 +33,7 @@ WORKDIR /build
 RUN <<_PIP
 #!/bin/bash
 set -e
-python -m pip --no-python-version-warning --disable-pip-version-check install --no-cache-dir --upgrade \
+python2 -m pip --no-python-version-warning --disable-pip-version-check install --no-cache-dir --upgrade \
   pip setuptools requests
 # requests required to install python-plexapi
 # dev requirements not necessary for docker image, significantly speeds up build since lxml doesn't need to build
@@ -48,9 +43,9 @@ _PIP
 RUN <<_BUILD
 #!/bin/bash
 set -e
-python -m pip --no-python-version-warning --disable-pip-version-check install --no-cache-dir --upgrade \
+python2 -m pip --no-python-version-warning --disable-pip-version-check install --no-cache-dir --upgrade \
   --target=./Contents/Libraries/Shared -r requirements.txt --no-warn-script-location
-python ./scripts/build_plist.py
+python2 ./scripts/build_plist.py
 _BUILD
 
 # clean

--- a/docs/source/contributing/contributing.rst
+++ b/docs/source/contributing/contributing.rst
@@ -1,3 +1,5 @@
+:github_url: https://github.com/LizardByte/Themerr-plex/tree/nightly/docs/source/contributing/contributing.rst
+
 Contributing
 ============
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,11 +7,13 @@ typing==3.10.0.0
 # youtube_dl is not capable or willing to create a new release so have to install from git
 # youtube_dl==2021.12.17
 # unknown if dependabot can update this
-git+https://github.com/ytdl-org/youtube-dl.git@26035bde46c0acc30dc053618451d9aeca4b7709#egg=youtube_dl
+# git+https://github.com/ytdl-org/youtube-dl.git@26035bde46c0acc30dc053618451d9aeca4b7709#egg=youtube_dl
+https://github.com/ytdl-org/youtube-dl/archive/26035bde46c0acc30dc053618451d9aeca4b7709.zip#egg=youtube_dl
 
 # custom python-plexapi supporting python 2.7
 # this is used to upload theme songs since Movie agents cannot correctly do so
-git+https://github.com/reenignearcher/python-plexapi.git@master-py2.7#egg=plexapi
+# git+https://github.com/reenignearcher/python-plexapi.git@master-py2.7#egg=plexapi
+https://github.com/reenignearcher/python-plexapi/archive/master-py2.7.zip#egg=plexapi
 
 # websocket-client is required for plexapi alert listener
 websocket-client==0.59.0;python_version<"3"


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Move docker image to Ubuntu 22.04.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
