### PR TITLE
fix(codec): improve compatibility with Apple devices

### DIFF
--- a/Contents/Code/default_prefs.py
+++ b/Contents/Code/default_prefs.py
@@ -1,4 +1,5 @@
 default_prefs = dict(
+    bool_prefer_mp4a_codec='True',
     int_plexapi_plexapi_timeout='180',
     int_plexapi_upload_retries_max='3',
     int_plexapi_upload_threads='3',

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -1,5 +1,12 @@
 [
 	{
+		"id": "bool_prefer_mp4a_codec",
+		"type": "bool",
+		"label": "Prefer MP4A AAC Codec (Improves compatibility with Apple devices)",
+		"default": "True",
+		"secure": "false"
+	},
+	{
 		"id": "int_plexapi_plexapi_timeout",
 		"type": "text",
 		"label": "PlexAPI Timeout, in seconds (min: 1)",

--- a/docs/source/about/usage.rst
+++ b/docs/source/about/usage.rst
@@ -25,6 +25,18 @@ Minimal setup is required to use Themerr-plex. In addition to the installation, 
 Preferences
 -----------
 
+Prefer MP4A AAC Codec
+^^^^^^^^^^^^^^^^^^^^^
+
+Description
+   Some Plex clients, such as AppleTV, do not support the Opus audio codec for theme songs. This setting will
+   force Themerr to select the MP4A AAC codec over the Opus codec when both are available. If the MP4A AAC codec is
+   not available, the Opus codec will be used and the theme song will not be playable on clients that do not support
+   the Opus codec.
+
+Default
+   True
+
 PlexAPI Timeout
 ^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR adds a new preference to prefer MP4A AAC codec over Opus codec, which should improve compatibility with Apple devices.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes #121 


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
