### PR TITLE
fix(ci): fix python 2.7 setup

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,9 +44,7 @@ jobs:
           path: Themerr-plex.bundle
 
       - name: Install Python 2.7
-        uses: actions/setup-python@v4
-        with:
-          python-version: '2.7'
+        uses: LizardByte/.github/actions/setup_python2@nightly
 
       - name: Set up Python 2.7 Dependencies
         working-directory: Themerr-plex.bundle

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -19,9 +19,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '2.7'
+        uses: LizardByte/.github/actions/setup_python2@nightly
 
       - name: Install python dependencies
         shell: bash
@@ -33,5 +31,6 @@ jobs:
           python -m pip --no-python-version-warning --disable-pip-version-check install -r requirements.txt
 
       - name: Test with pytest
+        shell: bash  # our Python 2.7 setup action doesn't support PowerShell
         run: |
           python -m pytest -v


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Fix Python 2.7 setup using new org action -> https://github.com/LizardByte/.github/pull/237

This change is required due to GitHub removing support for Python 2.7 in runners -> https://github.com/actions/setup-python/issues/672


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
