### PR TITLE
docs: fix readthedocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,6 +14,9 @@ build:
   jobs:
     pre_build:
       - python ./scripts/build_plist.py
+    post_build:
+      - rstcheck -r .  # lint rst files
+      # - rstfmt --check --diff -w 120 .  # check rst formatting
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -28,4 +31,3 @@ python:
   install:
     - requirements: requirements.txt  # plugin requirements
     - requirements: requirements-dev.txt  # docs requirements
-  system_packages: true

--- a/.rstcheck.cfg
+++ b/.rstcheck.cfg
@@ -1,0 +1,11 @@
+# configuration file for rstcheck, an rst linting tool
+# https://rstcheck.readthedocs.io/en/latest/usage/config
+
+[rstcheck]
+ignore_directives =
+    automodule,
+    include,
+    mdinclude,
+    todo,
+ignore_roles =
+    modname,

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 
 Overview
 ========
-LizardByte has the full documentation hosted on `Read the Docs <http://themerr-plex.readthedocs.io/>`_.
+LizardByte has the full documentation hosted on `Read the Docs <http://themerr-plex.readthedocs.io/>`__.
 
 About
 -----
@@ -13,7 +13,7 @@ This plugin contributes to the following metadata agents.
    - Plex Movie - `tv.plex.agents.movie`
    - Plex Movie (Legacy) - `com.plexapp.agents.imdb`
    - The Movie Database - `com.plexapp.agents.themoviedb`
-   - `RetroArcher <https://github.com/LizardByte/RetroArcher-plex>`_ - `dev.lizardbyte.retroarcher-plex`
+   - `RetroArcher <https://github.com/LizardByte/RetroArcher-plex>`__ - `dev.lizardbyte.retroarcher-plex`
 
 Integrations
 ------------

--- a/docs/source/about/installation.rst
+++ b/docs/source/about/installation.rst
@@ -12,7 +12,7 @@ The bundle is cross platform, meaning Linux, macOS, and Windows are supported.
 #. Extract the contents to your Plex Media Server Plugins directory.
 
 .. Tip:: See
-   `How do I find the Plug-Ins folder <https://support.plex.tv/articles/201106098-how-do-i-find-the-plug-ins-folder>`_
+   `How do I find the Plug-Ins folder <https://support.plex.tv/articles/201106098-how-do-i-find-the-plug-ins-folder>`__
    for information specific to your Plex server install.
 
 Docker

--- a/docs/source/about/troubleshooting.rst
+++ b/docs/source/about/troubleshooting.rst
@@ -6,14 +6,14 @@ Troubleshooting
 Plugin Logs
 -----------
 
-See `Plugin Log Files <https://support.plex.tv/articles/201106148-channel-log-files/>`_ for the plugin
+See `Plugin Log Files <https://support.plex.tv/articles/201106148-channel-log-files/>`__ for the plugin
 log directory.
 
 Plex uses rolling logs. There will be six log files available. The newest log file will be named
 ``dev.lizardbyte.themerr-plex.log``. There will be additional log files with the same name, appended with a `1-5`.
 
 It is best to replicate the issue you are experiencing, then review the latest log file. The information in the log
-file may seem cryptic. If so it would be best to reach out for `support <https://app.lizardbyte.dev/support>`_.
+file may seem cryptic. If so it would be best to reach out for `support <https://app.lizardbyte.dev/support>`__.
 
 .. Attention:: Before uploading logs, it would be wise to review the data in the log file. Plex does not filter
    the masked settings (e.g. credentials) out of the log file.
@@ -22,5 +22,5 @@ Plex Media Server Logs
 ----------------------
 
 If you have a more severe problem, you may need to troubleshoot an issue beyond the plugin itself. See
-`Plex Media Server Logs <https://support.plex.tv/articles/200250417-plex-media-server-log-files/>`_
+`Plex Media Server Logs <https://support.plex.tv/articles/200250417-plex-media-server-log-files/>`__
 for more information.

--- a/docs/source/about/usage.rst
+++ b/docs/source/about/usage.rst
@@ -27,13 +27,13 @@ Web UI
 
 A web interface is provided by the plugin. Currently the web ui only provides a couple of end points.
 
-/
-^
+/ (root)
+^^^^^^^^
 
 This endpoint will display a report showing the theme song status for each item in a library supported by Themerr-plex.
 A supported library is any that has the default agent as one supported by Themerr-plex.
 
-The report provides an easy means to contribute to `ThemerrDB <https://github.com/LizardByte/ThemerrDB>`_ by providing
+The report provides an easy means to contribute to `ThemerrDB <https://github.com/LizardByte/ThemerrDB>`__ by providing
 `Add/Edit` buttons for items that can be added to ThemerrDB.
 
 /status

--- a/docs/source/contributing/build.rst
+++ b/docs/source/contributing/build.rst
@@ -7,7 +7,7 @@ Python 2.7.
 
 Clone
 -----
-Ensure `git <https://git-scm.com/>`_ is installed and run the following:
+Ensure `git <https://git-scm.com/>`__ is installed and run the following:
 
    .. code-block:: bash
 
@@ -38,7 +38,7 @@ Build Plist
 
 npm dependencies
 ----------------
-Install nodejs and npm. Downloads available `here <https://nodejs.org/en/download/>`_.
+Install nodejs and npm. Downloads available `here <https://nodejs.org/en/download/>`__.
 
 Install npm dependencies.
    .. code-block:: bash

--- a/docs/source/contributing/contributing.rst
+++ b/docs/source/contributing/contributing.rst
@@ -4,4 +4,4 @@ Contributing
 ============
 
 Read our contribution guide in our organization level
-`docs <https://lizardbyte.readthedocs.io/en/latest/developers/contributing.html>`_.
+`docs <https://lizardbyte.readthedocs.io/en/latest/developers/contributing.html>`__.

--- a/docs/source/contributing/database.rst
+++ b/docs/source/contributing/database.rst
@@ -3,5 +3,5 @@
 Database
 ========
 
-The database of themes is held in our `ThemerrDB <https://github.com/LizardByte/ThemerrDB>`_ repository. To contribute
+The database of themes is held in our `ThemerrDB <https://github.com/LizardByte/ThemerrDB>`__ repository. To contribute
 to the database, follow the documentation there.

--- a/docs/source/contributing/testing.rst
+++ b/docs/source/contributing/testing.rst
@@ -5,7 +5,7 @@ Testing
 
 Flake8
 ------
-Themerr-plex uses `Flake8 <https://pypi.org/project/flake8/>`_ for enforcing consistent code styling. Flake8 is included
+Themerr-plex uses `Flake8 <https://pypi.org/project/flake8/>`__ for enforcing consistent code styling. Flake8 is included
 in the ``requirements-dev.txt``.
 
 The config file for flake8 is ``.flake8``. This is already included in the root of the repo and should not be modified.
@@ -17,10 +17,10 @@ Test with Flake8
 
 Sphinx
 ------
-Themerr-plex uses `Sphinx <https://www.sphinx-doc.org/en/master/>`_ for documentation building. Sphinx is included
+Themerr-plex uses `Sphinx <https://www.sphinx-doc.org/en/master/>`__ for documentation building. Sphinx is included
 in the ``requirements-dev.txt``.
 
-Themerr-plex follows `numpydoc <https://numpydoc.readthedocs.io/en/latest/format.html>`_ styling and formatting in
+Themerr-plex follows `numpydoc <https://numpydoc.readthedocs.io/en/latest/format.html>`__ styling and formatting in
 docstrings. This will be tested when building the docs. `numpydoc` is included in the ``requirements-dev.txt``.
 
 The config file for Sphinx is ``docs/source/conf.py``. This is already included in the root of the repo and should not
@@ -41,7 +41,7 @@ Test with Sphinx
 
 pytest
 ------
-Themerr-plex uses `pytest <https://pypi.org/project/pytest/>`_ for unit testing. pytest is included in the
+Themerr-plex uses `pytest <https://pypi.org/project/pytest/>`__ for unit testing. pytest is included in the
 ``requirements-dev.txt``.
 
 No config is required for pytest.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,6 @@ m2r2==0.3.2;python_version<"3"
 numpydoc==0.9.2;python_version<"3"
 git+https://github.com/LizardByte/plexhints.git#egg=plexhints  # type hinting library for plex development
 pytest==4.6.11;python_version<"3"
+rstcheck==3.5.0;python_version<"3"
 Sphinx==1.8.6;python_version<"3"
 sphinx-rtd-theme==1.2.0;python_version<"3"


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Fix readthedocs build and enable rstcheck (lint)


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
