### PR TITLE
test: increase plugin log search timeout

### DIFF
--- a/tests/functional/test_plex_plugin.py
+++ b/tests/functional/test_plex_plugin.py
@@ -11,7 +11,7 @@ def _check_themes(movies):
         assert item.theme, "No theme found for {}".format(item.title)
 
 
-def test_plugin_los(plugin_logs):
+def test_plugin_logs(plugin_logs):
     print('plugin_logs: {}'.format(plugin_logs))
     assert plugin_logs, "No plugin logs found"
 
@@ -19,13 +19,14 @@ def test_plugin_los(plugin_logs):
 def test_plugin_log_file(plugin_log_file):
     found = False
     count = 0
-    while not found and count < 60:  # plugin takes a little while to start on macOS
+    max_count = 120
+    while not found and count < max_count:  # plugin takes a little while to start on macOS
         count += 1
         if os.path.isfile(plugin_log_file):
             found = True
         else:
             time.sleep(1)
-    assert found, "After 60 seconds, plugin log file not found: {}".format(plugin_log_file)
+    assert found, "After {} seconds, plugin log file not found: {}".format(max_count, plugin_log_file)
 
 
 def test_plugin_log_file_exceptions(plugin_log_file):


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Increase plugin log search timeout to 2 minutes.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
