### PR TITLE
test: wait until plugin is ready

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,19 @@ SERVER_BASEURL = plexapi.CONFIG.get("auth.server_baseurl")
 SERVER_TOKEN = plexapi.CONFIG.get("auth.server_token")
 
 
+def wait_for_file(file_path, timeout=300):
+    # type: (str, int) -> None
+    found = False
+    count = 0
+    while not found and count < timeout:  # plugin takes a little while to start on macOS
+        count += 1
+        if os.path.isfile(file_path):
+            found = True
+        else:
+            time.sleep(1)
+    assert found, "After {} seconds, {} file not found".format(timeout, file_path)
+
+
 def wait_for_themes(movies):
     # ensure library is not refreshing
     while movies.refreshing:
@@ -90,6 +103,8 @@ def plugin_logs():
 def plugin_log_file():
     # the primary plugin log file
     plugin_log_file = os.path.join(os.environ['PLEX_PLUGIN_LOG_PATH'], "{}.log".format(constants.plugin_identifier))
+
+    wait_for_file(file_path=plugin_log_file, timeout=300)
 
     yield plugin_log_file
 

--- a/tests/functional/test_plex_plugin.py
+++ b/tests/functional/test_plex_plugin.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # standard imports
 import os
-import time
 
 
 def _check_themes(movies):
@@ -17,16 +16,7 @@ def test_plugin_logs(plugin_logs):
 
 
 def test_plugin_log_file(plugin_log_file):
-    found = False
-    count = 0
-    max_count = 120
-    while not found and count < max_count:  # plugin takes a little while to start on macOS
-        count += 1
-        if os.path.isfile(plugin_log_file):
-            found = True
-        else:
-            time.sleep(1)
-    assert found, "After {} seconds, plugin log file not found: {}".format(max_count, plugin_log_file)
+    assert os.path.isfile(plugin_log_file), "Plugin log file not found"
 
 
 def test_plugin_log_file_exceptions(plugin_log_file):


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Further improve tests, specifically waiting for the plugin to start due to delay on macOS.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
