### PR TITLE
ci: use commit hash for setup python action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,7 +44,8 @@ jobs:
           path: Themerr-plex.bundle
 
       - name: Set up Python
-        uses: LizardByte/setup-python-action@v2023.10.23-7bf3fc9
+        # dependabot cannot pick up our tags, so use the commit hash
+        uses: LizardByte/setup-python-action@8851ba6849c1003134ced0581b34204f0c322cad
         with:
           python-version: '2.7'
 
@@ -145,7 +146,8 @@ jobs:
           rm Themerr-plex.bundle.zip
 
       - name: Set up Python
-        uses: LizardByte/setup-python-action@v2023.10.23-7bf3fc9
+        # dependabot cannot pick up our tags, so use the commit hash
+        uses: LizardByte/setup-python-action@8851ba6849c1003134ced0581b34204f0c322cad
         with:
           python-version: '2.7'
 
@@ -203,7 +205,7 @@ jobs:
           cat "${log_file}"
 
       - name: Upload coverage
-        # any except cancelled or skipped
+        # any except canceled or skipped
         if: always() && (steps.test.outcome == 'success' || steps.test.outcome == 'failure')
         uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Use commit hash for setup python action, so that dependabot can (hopefully) pick up the changes.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
