### PR TITLE
Add error handling and logging for Youtube-DL

### DIFF
--- a/Contents/Code/youtube_dl_helper.py
+++ b/Contents/Code/youtube_dl_helper.py
@@ -20,6 +20,7 @@ import youtube_dl
 # get the plugin logger
 plugin_logger = logging.getLogger(plugin_identifier)
 
+
 def process_youtube(url):
     # type: (str) -> Optional[str]
     """

--- a/Contents/Code/youtube_dl_helper.py
+++ b/Contents/Code/youtube_dl_helper.py
@@ -12,6 +12,7 @@ else:  # the code is running outside of Plex
 # imports from Libraries\Shared
 from constants import plugin_identifier
 from typing import Optional
+import logging
 import youtube_dl
 
 # get the plugin logger

--- a/Contents/Code/youtube_dl_helper.py
+++ b/Contents/Code/youtube_dl_helper.py
@@ -39,12 +39,11 @@ def process_youtube(url):
     """
     youtube_dl_params = dict(
         logger=plugin_logger,
-        verbose=True,
-        socket_timeout=10,
         outtmpl=u'%(id)s.%(ext)s',
-        youtube_include_dash_manifest=False,
-        username=Prefs['str_youtube_user'] if Prefs['str_youtube_user'] else None,
         password=Prefs['str_youtube_passwd'] if Prefs['str_youtube_passwd'] else None,
+        socket_timeout=10,
+        username=Prefs['str_youtube_user'] if Prefs['str_youtube_user'] else None,
+        youtube_include_dash_manifest=False,
     )
 
     ydl = youtube_dl.YoutubeDL(params=youtube_dl_params)

--- a/Contents/Code/youtube_dl_helper.py
+++ b/Contents/Code/youtube_dl_helper.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 
+# standard imports
+import logging
+
 # plex debugging
 try:
     import plexhints  # noqa: F401
@@ -12,7 +15,6 @@ else:  # the code is running outside of Plex
 # imports from Libraries\Shared
 from constants import plugin_identifier
 from typing import Optional
-import logging
 import youtube_dl
 
 # get the plugin logger

--- a/Contents/Code/youtube_dl_helper.py
+++ b/Contents/Code/youtube_dl_helper.py
@@ -10,29 +10,12 @@ else:  # the code is running outside of Plex
     from plexhints.prefs_kit import Prefs  # prefs kit
 
 # imports from Libraries\Shared
+from constants import plugin_identifier
 from typing import Optional
 import youtube_dl
 
-class LoggerProxy(object):
-    def debug(self, msg, *args, **kwargs):
-        Log.Debug(msg, *args, **kwargs)
-
-    def info(self, msg, *args, **kwargs):
-        Log.Info(msg, *args, **kwargs)
-
-    def warning(self, msg, *args, **kwargs):
-        Log.Warn(msg, *args, **kwargs)
-
-    def error(self, msg, *args, **kwargs):
-        Log.Error(msg, *args, **kwargs)
-
-    def critical(self, msg, *args, **kwargs):
-        Log.Critical(msg, *args, **kwargs)
-
-    def exception(self, msg, *args, **kwargs):
-        Log.Exception(msg, exc_info=True, *args, **kwargs)
-
-youtube_logger = LoggerProxy()
+# get the plugin logger
+plugin_logger = logging.getLogger(plugin_identifier)
 
 def process_youtube(url):
     # type: (str) -> Optional[str]
@@ -55,7 +38,7 @@ def process_youtube(url):
     ...
     """
     youtube_dl_params = dict(
-        logger=youtube_logger,
+        logger=plugin_logger,
         verbose=True,
         socket_timeout=10,
         outtmpl=u'%(id)s.%(ext)s',

--- a/tests/unit/test_youtube_dl_helper.py
+++ b/tests/unit/test_youtube_dl_helper.py
@@ -1,8 +1,4 @@
 # -*- coding: utf-8 -*-
-# lib imports
-import pytest
-from youtube_dl import DownloadError
-
 # local imports
 from Code import youtube_dl_helper
 

--- a/tests/unit/test_youtube_dl_helper.py
+++ b/tests/unit/test_youtube_dl_helper.py
@@ -26,5 +26,5 @@ def test_process_youtube_invalid():
         'https://blahblahblah',
     ]
     for url in invalid_urls:
-        with pytest.raises(DownloadError):
-            youtube_dl_helper.process_youtube(url=url)
+        audio_url = youtube_dl_helper.process_youtube(url=url)
+        assert audio_url is None


### PR DESCRIPTION
## Description

- no code was present to handle YoutubeDL raising an exception. If such a case were to happen previously, the whole thread would crash; in practice this means that if any movie in the library can't be downloaded for any reason, the worker thread trying to download it will crash and stop processing any more content. In the worst case (e.g. mine) you can end up with all threads hung. Refreshing metadata or restarting the plugin doesn't change anything, the problem is logical and deterministic. Errors are now handled properly and printed to the plugin logs, and the process can continue.
- also, a typo in the YoutubeDL call is fixed (`outmpl` -> `outtmpl`)


### Issues Fixed or Closed
- Fixes #163

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
