### PR TITLE
Fix AlertListener on IPv6-aware hosts

### DIFF
--- a/Contents/Code/plex_api_helper.py
+++ b/Contents/Code/plex_api_helper.py
@@ -38,7 +38,7 @@ plex = None
 q = queue.Queue()
 
 
-plex_url = 'http://127.0.0.1:32400'
+plex_url = 'http://127.0.0.1:32400'  # the explicit IPv4 address is used because `localhost` can resolve to ::1, which `websocket` rejects
 plex_token = os.environ.get('PLEXTOKEN')
 
 plex_section_type_settings_map = dict(

--- a/Contents/Code/plex_api_helper.py
+++ b/Contents/Code/plex_api_helper.py
@@ -38,7 +38,7 @@ plex = None
 q = queue.Queue()
 
 
-plex_url = 'http://localhost:32400'
+plex_url = 'http://127.0.0.1:32400'
 plex_token = os.environ.get('PLEXTOKEN')
 
 plex_section_type_settings_map = dict(

--- a/Contents/Code/plex_api_helper.py
+++ b/Contents/Code/plex_api_helper.py
@@ -38,7 +38,8 @@ plex = None
 q = queue.Queue()
 
 
-plex_url = 'http://127.0.0.1:32400'  # the explicit IPv4 address is used because `localhost` can resolve to ::1, which `websocket` rejects
+# the explicit IPv4 address is used because `localhost` can resolve to ::1, which `websocket` rejects
+plex_url = 'http://127.0.0.1:32400'
 plex_token = os.environ.get('PLEXTOKEN')
 
 plex_section_type_settings_map = dict(


### PR DESCRIPTION
## Description

- on many Linux machines, `localhost` resolves to `::1`. The `websocket` module used here expects an `AF_INET` address, so it expectedly crashes when passed an IPv6 address such as `::1`. The default URL used for reaching Plex is modified to `127.0.0.1` to prevent this.


### Issues Fixed or Closed
- Fixes #143

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
