### PR TITLE
fix: Add error handling around update_plex_item to prevent hang

### DIFF
--- a/Contents/Code/plex_api_helper.py
+++ b/Contents/Code/plex_api_helper.py
@@ -502,7 +502,10 @@ def process_queue():
     """
     while True:
         rating_key = q.get()  # get the rating_key from the queue
-        update_plex_item(rating_key=rating_key)  # process that rating_key
+        try:
+            update_plex_item(rating_key=rating_key)  # process that rating_key
+        except Exception as e:
+            Log.Exception('Unexpected error processing rating key: %s, error: %s' % (rating_key, e))
         q.task_done()  # tells the queue that we are done with this item
 
 


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
see title

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
