### PR TITLE
fix: Move skip check before call to Youtube-DL

### DIFF
--- a/Contents/Code/constants.py
+++ b/Contents/Code/constants.py
@@ -99,3 +99,27 @@ issue_urls = dict(
         base_url, issue_label, issue_template, title_prefix['movie_collections'], '{}', url_name,
         url_prefix['movie_collections'], '{}'),
 )
+
+media_type_dict = dict(
+    art=dict(
+        method=lambda item: item.uploadArt,
+        type='art',
+        name='art',
+        themerr_data_key='art_url',
+        remove_pref='bool_remove_unused_art',
+    ),
+    posters=dict(
+        method=lambda item: item.uploadPoster,
+        type='posters',
+        name='poster',
+        themerr_data_key='poster_url',
+        remove_pref='bool_remove_unused_posters',
+    ),
+    themes=dict(
+        method=lambda item: item.uploadTheme,
+        type='themes',
+        name='theme',
+        themerr_data_key='youtube_theme_url',
+        remove_pref='bool_remove_unused_theme_songs',
+    ),
+)

--- a/Contents/Code/plex_api_helper.py
+++ b/Contents/Code/plex_api_helper.py
@@ -205,7 +205,7 @@ def update_plex_item(rating_key):
                             Log.Exception('{}: Error processing youtube url: {}'.format(item.ratingKey, e))
                         else:
                             if theme_url:
-                                add_media(item=item, media_type='themes', 
+                                add_media(item=item, media_type='themes',
                                           media_url_id=yt_video_url, media_url=theme_url)
 
 
@@ -242,6 +242,7 @@ def add_media(item, media_type, media_url_id, media_file=None, media_url=None):
     """
     uploaded = False
 
+    settings_hash = general_helper.get_themerr_settings_hash()
     themerr_data = general_helper.get_themerr_json_data(item=item)
 
     if media_file or media_url:

--- a/Contents/Code/plex_api_helper.py
+++ b/Contents/Code/plex_api_helper.py
@@ -283,7 +283,6 @@ def add_media(item, media_type, media_url_id, media_file=None, media_url=None):
         ))
 
     if uploaded:
-        settings_hash = general_helper.get_themerr_settings_hash()
         # new data for themerr.json
         new_themerr_data = dict(
             settings_hash=settings_hash

--- a/Contents/Code/plex_api_helper.py
+++ b/Contents/Code/plex_api_helper.py
@@ -27,7 +27,7 @@ import plexapi.server
 from plexapi.utils import reverseSearchType
 
 # local imports
-from constants import contributes_to, guid_map
+from constants import contributes_to, guid_map, media_type_dict
 import general_helper
 import lizardbyte_db_helper
 import tmdb_helper
@@ -185,10 +185,28 @@ def update_plex_item(rating_key):
                 except KeyError:
                     Log.Info('{}: No theme song found for {} ({})'.format(item.ratingKey, item.title, item.year))
                 else:
-                    theme_url = process_youtube(url=yt_video_url)
+                    settings_hash = general_helper.get_themerr_settings_hash()
+                    themerr_data = general_helper.get_themerr_json_data(item=item)
 
-                    if theme_url:
-                        add_media(item=item, media_type='themes', media_url_id=yt_video_url, media_url=theme_url)
+                    try:
+                        skip = themerr_data['settings_hash'] == settings_hash \
+                            and themerr_data[media_type_dict['themes']['themerr_data_key']] == yt_video_url
+                    except KeyError:
+                        skip = False
+
+                    if skip:
+                        Log.Info('Skipping {} for type: {}, title: {}, rating_key: {}'.format(
+                            media_type_dict['themes']['name'], item.type, item.title, item.ratingKey
+                        ))
+                    else:
+                        try:
+                            theme_url = process_youtube(url=yt_video_url)
+                        except Exception as e:
+                            Log.Exception('{}: Error processing youtube url: {}'.format(item.ratingKey, e))
+                        else:
+                            if theme_url:
+                                add_media(item=item, media_type='themes', media_url_id=yt_video_url, media_url=theme_url)
+                            
 
 
 def add_media(item, media_type, media_url_id, media_file=None, media_url=None):
@@ -224,32 +242,8 @@ def add_media(item, media_type, media_url_id, media_file=None, media_url=None):
     """
     uploaded = False
 
-    settings_hash = general_helper.get_themerr_settings_hash()
+    
     themerr_data = general_helper.get_themerr_json_data(item=item)
-
-    media_type_dict = dict(
-        art=dict(
-            method=item.uploadArt,
-            type='art',
-            name='art',
-            themerr_data_key='art_url',
-            remove_pref='bool_remove_unused_art',
-        ),
-        posters=dict(
-            method=item.uploadPoster,
-            type='posters',
-            name='poster',
-            themerr_data_key='poster_url',
-            remove_pref='bool_remove_unused_posters',
-        ),
-        themes=dict(
-            method=item.uploadTheme,
-            type='themes',
-            name='theme',
-            themerr_data_key='youtube_theme_url',
-            remove_pref='bool_remove_unused_theme_songs',
-        ),
-    )
 
     if media_file or media_url:
         global plex
@@ -280,15 +274,16 @@ def add_media(item, media_type, media_url_id, media_file=None, media_url=None):
             media_type_dict[media_type]['name'], item.type, item.title, item.ratingKey
         ))
         if media_file:
-            uploaded = upload_media(item=item, method=media_type_dict[media_type]['method'], filepath=media_file)
+            uploaded = upload_media(item=item, method=media_type_dict[media_type]['method'](item), filepath=media_file)
         if media_url:
-            uploaded = upload_media(item=item, method=media_type_dict[media_type]['method'], url=media_url)
+            uploaded = upload_media(item=item, method=media_type_dict[media_type]['method'](item), url=media_url)
     else:
         Log.Warning('No theme songs provided for type: {}, title: {}, rating_key: {}'.format(
             item.type, item.title, item.ratingKey
         ))
 
     if uploaded:
+        settings_hash = general_helper.get_themerr_settings_hash()
         # new data for themerr.json
         new_themerr_data = dict(
             settings_hash=settings_hash

--- a/Contents/Code/plex_api_helper.py
+++ b/Contents/Code/plex_api_helper.py
@@ -205,8 +205,8 @@ def update_plex_item(rating_key):
                             Log.Exception('{}: Error processing youtube url: {}'.format(item.ratingKey, e))
                         else:
                             if theme_url:
-                                add_media(item=item, media_type='themes', media_url_id=yt_video_url, media_url=theme_url)
-                            
+                                add_media(item=item, media_type='themes', 
+                                          media_url_id=yt_video_url, media_url=theme_url)
 
 
 def add_media(item, media_type, media_url_id, media_file=None, media_url=None):
@@ -242,7 +242,6 @@ def add_media(item, media_type, media_url_id, media_file=None, media_url=None):
     """
     uploaded = False
 
-    
     themerr_data = general_helper.get_themerr_json_data(item=item)
 
     if media_file or media_url:


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Before, the skip check was done in `add_media`, i.e. after the call to `process_youtube`. As a result, even for media for which Themerr had already downloaded a theme, Youtube-DL was still called to try and get the stream URL, which 

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
