### PR TITLE
fix: disable auto-reload since it is not needed and only harms perf

### DIFF
--- a/Contents/Code/plex_api_helper.py
+++ b/Contents/Code/plex_api_helper.py
@@ -37,6 +37,9 @@ plex = None
 
 q = queue.Queue()
 
+# disable auto-reload, because Themerr doesn't rely on it, so it will only slow down the app
+# when accessing a missing field
+os.environ["PLEXAPI_PLEXAPI_AUTORELOAD"] = "false"
 
 # the explicit IPv4 address is used because `localhost` can resolve to ::1, which `websocket` rejects
 plex_url = 'http://127.0.0.1:32400'


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This disable auto-reloading of fields by PlexAPI. This feature is not needed by Themerr. If enabled, it performs a web request everytime a missing field is accessed. On my machine, the webUI takes more than 10 min to load with autoreload, and less than a second without.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
