### PR TITLE
fix: don't update locked fields + unlock fields after update

### DIFF
--- a/Contents/Code/constants.py
+++ b/Contents/Code/constants.py
@@ -106,6 +106,7 @@ media_type_dict = dict(
         name='art',
         themerr_data_key='art_url',
         remove_pref='bool_remove_unused_art',
+        plex_field='art',
     ),
     posters=dict(
         method=lambda item: item.uploadPoster,
@@ -113,6 +114,7 @@ media_type_dict = dict(
         name='poster',
         themerr_data_key='poster_url',
         remove_pref='bool_remove_unused_posters',
+        plex_field='thumb',
     ),
     themes=dict(
         method=lambda item: item.uploadTheme,
@@ -120,5 +122,6 @@ media_type_dict = dict(
         name='theme',
         themerr_data_key='youtube_theme_url',
         remove_pref='bool_remove_unused_theme_songs',
+        plex_field='theme',
     ),
 )

--- a/Contents/Code/plex_api_helper.py
+++ b/Contents/Code/plex_api_helper.py
@@ -312,7 +312,11 @@ def add_media(item, media_type, media_url_id, media_file=None, media_url=None):
         general_helper.update_themerr_data_file(item=item, new_themerr_data=new_themerr_data)
 
         # unlock the field since it contains an automatically added value
-        getattr(item, "_edit")(**{'{}.locked'.format(media_type_dict[media_type]['plex_field']): 0})
+        edit_field = "{}.locked".format(media_type_dict[media_type]['plex_field'])
+        edits = {
+            edit_field : 0,
+        }
+        item.edit(**edits)
     else:
         Log.Debug('Could not upload {} for type: {}, title: {}, rating_key: {}'.format(
             media_type_dict[media_type]['name'], item.type, item.title, item.ratingKey

--- a/Contents/Code/plex_api_helper.py
+++ b/Contents/Code/plex_api_helper.py
@@ -314,9 +314,18 @@ def add_media(item, media_type, media_url_id, media_file=None, media_url=None):
         # unlock the field since it contains an automatically added value
         edit_field = "{}.locked".format(media_type_dict[media_type]['plex_field'])
         edits = {
-            edit_field : 0,
+            edit_field: 0,
         }
-        item.edit(**edits)
+        count = 0
+        while count < 3:  # there are random read timeouts
+            try:
+                item.edit(**edits)
+            except requests.ReadTimeout as e:
+                Log.Error('{}: Error unlocking field: {}'.format(item.ratingKey, e))
+                time.sleep(5)
+                count += 1
+            else:
+                break
     else:
         Log.Debug('Could not upload {} for type: {}, title: {}, rating_key: {}'.format(
             media_type_dict[media_type]['name'], item.type, item.title, item.ratingKey

--- a/Contents/Code/plex_api_helper.py
+++ b/Contents/Code/plex_api_helper.py
@@ -107,11 +107,12 @@ def is_field_locked(item, field_name):
     -------
     bool
         True if the field is locked, False otherwise.
-    """
 
     Examples
     --------
-    # add an example please
+    >>> is_field_locked(item=..., field_name='theme')
+    False
+    """
     for field in item.fields:
         if field.name == field_name:
             return field.locked

--- a/Contents/Code/plex_api_helper.py
+++ b/Contents/Code/plex_api_helper.py
@@ -289,7 +289,7 @@ def add_media(item, media_type, media_url_id, media_file=None, media_url=None):
     settings_hash = general_helper.get_themerr_settings_hash()
     themerr_data = general_helper.get_themerr_json_data(item=item)
 
-    if is_field_locked(item, media_type_dict[media_type]['plex_field']):
+    if is_field_locked(item=item, field_name=media_type_dict[media_type]['plex_field']):
         Log.Info('Not overwriting locked "{}" for {}: {}'.format(
             media_type_dict[media_type]['name'], item.type, item.title
         ))

--- a/Contents/Code/plex_api_helper.py
+++ b/Contents/Code/plex_api_helper.py
@@ -90,7 +90,7 @@ def setup_plexapi():
 
 
 def is_field_locked(item, field_name):
-    # type: (any, str) -> bool
+    # type: (PlexPartialObject, str) -> bool
     """
     Check if the specified field is locked.
     
@@ -98,7 +98,7 @@ def is_field_locked(item, field_name):
 
     Parameters
     ----------
-    item : any
+    item : PlexPartialObject
         The Plex item to check.
     field_name : str
         The name of the field to check.

--- a/Contents/Code/plex_api_helper.py
+++ b/Contents/Code/plex_api_helper.py
@@ -92,8 +92,9 @@ def setup_plexapi():
 def is_field_locked(item, field_name):
     # type: (any, str) -> bool
     """
-    Check if the specified field is locked -- i.e. if the user has manually set a value for it and does not want
-    it to be updated by an automated process.
+    Check if the specified field is locked.
+    
+    This is used to ensure a field has not been manually set by the user.
 
     Parameters
     ----------
@@ -107,6 +108,10 @@ def is_field_locked(item, field_name):
     bool
         True if the field is locked, False otherwise.
     """
+
+    Examples
+    --------
+    # add an example please
     for field in item.fields:
         if field.name == field_name:
             return field.locked
@@ -200,7 +205,7 @@ def update_plex_item(rating_key):
                             add_media(item=item, media_type='art', media_url_id=data['backdrop_path'], media_url=url)
                         # update summary
                         if is_field_locked(item, "summary"):
-                            Log.Info('Not overwriting locked summary for collection: {}'.format(item.title))
+                            Log.Debug('Not overwriting locked summary for collection: {}'.format(item.title))
                         else:
                             try:
                                 summary = data['overview']
@@ -215,7 +220,7 @@ def update_plex_item(rating_key):
                                         Log.Error('{}: Error updating summary: {}'.format(item.ratingKey, e))
 
                 if is_field_locked(item, "theme"):
-                    Log.Info('Not overwriting locked theme for {}: {}'.format(item.type, item.title))
+                    Log.Debug('Not overwriting locked theme for {}: {}'.format(item.type, item.title))
                 else:
                     # get youtube_url
                     try:

--- a/Contents/Code/plex_api_helper.py
+++ b/Contents/Code/plex_api_helper.py
@@ -89,36 +89,6 @@ def setup_plexapi():
     return plex
 
 
-def is_field_locked(item, field_name):
-    # type: (PlexPartialObject, str) -> bool
-    """
-    Check if the specified field is locked.
-    
-    This is used to ensure a field has not been manually set by the user.
-
-    Parameters
-    ----------
-    item : PlexPartialObject
-        The Plex item to check.
-    field_name : str
-        The name of the field to check.
-
-    Returns
-    -------
-    bool
-        True if the field is locked, False otherwise.
-
-    Examples
-    --------
-    >>> is_field_locked(item=..., field_name='theme')
-    False
-    """
-    for field in item.fields:
-        if field.name == field_name:
-            return field.locked
-    return False
-
-
 def update_plex_item(rating_key):
     # type: (int) -> bool
     """
@@ -205,7 +175,7 @@ def update_plex_item(rating_key):
                         else:
                             add_media(item=item, media_type='art', media_url_id=data['backdrop_path'], media_url=url)
                         # update summary
-                        if is_field_locked(item=item, field_name="summary"):
+                        if item.isLocked(field='summary'):
                             Log.Debug('Not overwriting locked summary for collection: {}'.format(item.title))
                         else:
                             try:
@@ -220,7 +190,7 @@ def update_plex_item(rating_key):
                                     except Exception as e:
                                         Log.Error('{}: Error updating summary: {}'.format(item.ratingKey, e))
 
-                if is_field_locked(item=item, field_name="theme"):
+                if item.isLocked(field='theme'):
                     Log.Debug('Not overwriting locked theme for {}: {}'.format(item.type, item.title))
                 else:
                     # get youtube_url
@@ -289,7 +259,7 @@ def add_media(item, media_type, media_url_id, media_file=None, media_url=None):
     settings_hash = general_helper.get_themerr_settings_hash()
     themerr_data = general_helper.get_themerr_json_data(item=item)
 
-    if is_field_locked(item=item, field_name=media_type_dict[media_type]['plex_field']):
+    if item.isLocked(field=media_type_dict[media_type]['plex_field']):
         Log.Info('Not overwriting locked "{}" for {}: {}'.format(
             media_type_dict[media_type]['name'], item.type, item.title
         ))

--- a/Contents/Code/plex_api_helper.py
+++ b/Contents/Code/plex_api_helper.py
@@ -89,6 +89,30 @@ def setup_plexapi():
     return plex
 
 
+def is_field_locked(item, field_name):
+    # type: (any, str) -> bool
+    """
+    Check if the specified field is locked -- i.e. if the user has manually set a value for it and does not want
+    it to be updated by an automated process.
+
+    Parameters
+    ----------
+    item : any
+        The Plex item to check.
+    field_name : str
+        The name of the field to check.
+
+    Returns
+    -------
+    bool
+        True if the field is locked, False otherwise.
+    """
+    for field in item.fields:
+        if field.name == field_name:
+            return field.locked
+    return False
+
+
 def update_plex_item(rating_key):
     # type: (int) -> bool
     """
@@ -175,46 +199,52 @@ def update_plex_item(rating_key):
                         else:
                             add_media(item=item, media_type='art', media_url_id=data['backdrop_path'], media_url=url)
                         # update summary
-                        try:
-                            summary = data['overview']
-                        except KeyError:
-                            pass
+                        if is_field_locked(item, "summary"):
+                            Log.Info('Not overwriting locked summary for collection: {}'.format(item.title))
                         else:
-                            if item.summary != summary:
-                                Log.Info('Updating summary for collection: {}'.format(item.title))
-                                try:
-                                    item.editSummary(summary=summary, locked=False)
-                                except Exception as e:
-                                    Log.Error('{}: Error updating summary: {}'.format(item.ratingKey, e))
+                            try:
+                                summary = data['overview']
+                            except KeyError:
+                                pass
+                            else:
+                                if item.summary != summary:
+                                    Log.Info('Updating summary for collection: {}'.format(item.title))
+                                    try:
+                                        item.editSummary(summary=summary, locked=False)
+                                    except Exception as e:
+                                        Log.Error('{}: Error updating summary: {}'.format(item.ratingKey, e))
 
-                # get youtube_url
-                try:
-                    yt_video_url = data['youtube_theme_url']
-                except KeyError:
-                    Log.Info('{}: No theme song found for {} ({})'.format(item.ratingKey, item.title, item.year))
+                if is_field_locked(item, "theme"):
+                    Log.Info('Not overwriting locked theme for {}: {}'.format(item.type, item.title))
                 else:
-                    settings_hash = general_helper.get_themerr_settings_hash()
-                    themerr_data = general_helper.get_themerr_json_data(item=item)
-
+                    # get youtube_url
                     try:
-                        skip = themerr_data['settings_hash'] == settings_hash \
-                            and themerr_data[media_type_dict['themes']['themerr_data_key']] == yt_video_url
+                        yt_video_url = data['youtube_theme_url']
                     except KeyError:
-                        skip = False
-
-                    if skip:
-                        Log.Info('Skipping {} for type: {}, title: {}, rating_key: {}'.format(
-                            media_type_dict['themes']['name'], item.type, item.title, item.ratingKey
-                        ))
+                        Log.Info('{}: No theme song found for {} ({})'.format(item.ratingKey, item.title, item.year))
                     else:
+                        settings_hash = general_helper.get_themerr_settings_hash()
+                        themerr_data = general_helper.get_themerr_json_data(item=item)
+
                         try:
-                            theme_url = process_youtube(url=yt_video_url)
-                        except Exception as e:
-                            Log.Exception('{}: Error processing youtube url: {}'.format(item.ratingKey, e))
+                            skip = themerr_data['settings_hash'] == settings_hash \
+                                and themerr_data[media_type_dict['themes']['themerr_data_key']] == yt_video_url
+                        except KeyError:
+                            skip = False
+
+                        if skip:
+                            Log.Info('Skipping {} for type: {}, title: {}, rating_key: {}'.format(
+                                media_type_dict['themes']['name'], item.type, item.title, item.ratingKey
+                            ))
                         else:
-                            if theme_url:
-                                add_media(item=item, media_type='themes',
-                                          media_url_id=yt_video_url, media_url=theme_url)
+                            try:
+                                theme_url = process_youtube(url=yt_video_url)
+                            except Exception as e:
+                                Log.Exception('{}: Error processing youtube url: {}'.format(item.ratingKey, e))
+                            else:
+                                if theme_url:
+                                    add_media(item=item, media_type='themes',
+                                            media_url_id=yt_video_url, media_url=theme_url)
 
 
 def add_media(item, media_type, media_url_id, media_file=None, media_url=None):
@@ -252,6 +282,12 @@ def add_media(item, media_type, media_url_id, media_file=None, media_url=None):
 
     settings_hash = general_helper.get_themerr_settings_hash()
     themerr_data = general_helper.get_themerr_json_data(item=item)
+
+    if is_field_locked(item, media_type_dict[media_type]['plex_field']):
+        Log.Info('Not overwriting locked "{}" for {}: {}'.format(
+            media_type_dict[media_type]['name'], item.type, item.title
+        ))
+        return False
 
     if media_file or media_url:
         global plex
@@ -298,6 +334,9 @@ def add_media(item, media_type, media_url_id, media_file=None, media_url=None):
         new_themerr_data[media_type_dict[media_type]['themerr_data_key']] = media_url_id
 
         general_helper.update_themerr_data_file(item=item, new_themerr_data=new_themerr_data)
+
+        # unlock the field since it contains an automatically added value
+        getattr(item, "_edit")(**{'{}.locked'.format(media_type_dict[media_type]['plex_field']): 0})
     else:
         Log.Debug('Could not upload {} for type: {}, title: {}, rating_key: {}'.format(
             media_type_dict[media_type]['name'], item.type, item.title, item.ratingKey

--- a/Contents/Code/plex_api_helper.py
+++ b/Contents/Code/plex_api_helper.py
@@ -205,7 +205,7 @@ def update_plex_item(rating_key):
                         else:
                             add_media(item=item, media_type='art', media_url_id=data['backdrop_path'], media_url=url)
                         # update summary
-                        if is_field_locked(item, "summary"):
+                        if is_field_locked(item=item, field_name="summary"):
                             Log.Debug('Not overwriting locked summary for collection: {}'.format(item.title))
                         else:
                             try:
@@ -220,7 +220,7 @@ def update_plex_item(rating_key):
                                     except Exception as e:
                                         Log.Error('{}: Error updating summary: {}'.format(item.ratingKey, e))
 
-                if is_field_locked(item, "theme"):
+                if is_field_locked(item=item, field_name="theme"):
                     Log.Debug('Not overwriting locked theme for {}: {}'.format(item.type, item.title))
                 else:
                     # get youtube_url
@@ -250,7 +250,7 @@ def update_plex_item(rating_key):
                             else:
                                 if theme_url:
                                     add_media(item=item, media_type='themes',
-                                            media_url_id=yt_video_url, media_url=theme_url)
+                                              media_url_id=yt_video_url, media_url=theme_url)
 
 
 def add_media(item, media_type, media_url_id, media_file=None, media_url=None):


### PR DESCRIPTION
## Description
Locked fields will not be updated by Themerr. Fields updated by Themerr will be marked as non-locked.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
