### PR TITLE
fix: correct issue where database_cache may be updated in parallel

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -184,6 +184,5 @@ def collection_themoviedb_agent(plex, movies_themoviedb_agent, movie_themoviedb_
 @pytest.fixture(scope='function')
 def empty_themerr_db_cache():
     themerr_db_helper.database_cache = {}  # reset the cache
-    themerr_db_helper.cache_updating = False
     themerr_db_helper.last_cache_update = 0
     return

--- a/tests/unit/test_themerr_db_helper.py
+++ b/tests/unit/test_themerr_db_helper.py
@@ -8,7 +8,6 @@ from Code import themerr_db_helper
 def test_update_cache(empty_themerr_db_cache):
     themerr_db_helper.update_cache()
     assert themerr_db_helper.last_cache_update > 0, 'Cache update did not complete'
-    assert themerr_db_helper.cache_updating is False, 'Cache update did not complete'
 
     assert "movies" in themerr_db_helper.database_cache, 'Cache does not contain movies'
     assert "movie_collections" in themerr_db_helper.database_cache, 'Cache does not contain movie_collections'


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
There is a potential for the database_cache to be updated in parallel.

I'm not 100% sure the cause of this error, but using a lock should be more reliable.

```txt
2023-11-12 22:22:38,763 (1cb0) :  CRITICAL (core:574) - JSON encoding error (most recent call last):
  File "C:\Program Files (x86)\Plex\Plex Media Server\Resources\Plug-ins-8f4248874\Framework.bundle\Contents\Resources\Versions\2\Python\Framework\components\data.py", line 187, in to_string
    return simplejson.dumps(obj)
  File "C:\Program Files (x86)\Plex\Plex Media Server\Resources\Python\lib\python2.7\site-packages\simplejson\__init__.py", line 354, in dumps
    return _default_encoder.encode(obj)
  File "C:\Program Files (x86)\Plex\Plex Media Server\Resources\Python\lib\python2.7\site-packages\simplejson\encoder.py", line 264, in encode
    chunks = list(chunks)
  File "C:\Program Files (x86)\Plex\Plex Media Server\Resources\Python\lib\python2.7\site-packages\simplejson\encoder.py", line 612, in _iterencode
    for chunk in _iterencode_dict(o, _current_indent_level):
  File "C:\Program Files (x86)\Plex\Plex Media Server\Resources\Python\lib\python2.7\site-packages\simplejson\encoder.py", line 521, in _iterencode_dict
    for key, value in items:
RuntimeError: dictionary changed size during iteration
```

I experienced the above error when I attempted to refresh the home page a couple of times before the refresh completed.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
