### PR TITLE
fix(ui): progress bar will now fill to max

### DIFF
--- a/Contents/Resources/web/templates/home.html
+++ b/Contents/Resources/web/templates/home.html
@@ -51,8 +51,8 @@
                         </div>
                         <!-- set the remainder to gray -->
                         <div class="progress-bar bg-secondary" role="progressbar"
-                             style="width: {{ 101 - items[section]['media_percent_complete'] }}%"
-                             aria-valuenow="{{ 101 - items[section]['media_percent_complete'] }}"
+                             style="width: {{ 100 - items[section]['media_percent_complete'] }}%"
+                             aria-valuenow="{{ 100 - items[section]['media_percent_complete'] }}"
                              aria-valuemin="0" aria-valuemax="100">
                         </div>
                     </div>


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
There is an issue where the progress bar will not fill to the max, due to an offset of 1.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
