### PR TITLE
fix(ui): use correct action button for themerr provided items

### DIFF
--- a/Contents/Code/webapp.py
+++ b/Contents/Code/webapp.py
@@ -260,6 +260,9 @@ def home():
             item_agent = database_info[2]
             database_id = database_info[3]
 
+            og_db = database
+            og_db_id = database_id
+
             try:
                 year = item.year
             except AttributeError:
@@ -320,7 +323,10 @@ def home():
                 item_issue_url = issue_url.format(issue_title, database_id if database_id else '')
 
             if database_type and themerr_db_helper.item_exists(
-                    database_type=database_type, database=database, id=database_id):
+                    database_type=database_type,
+                    database=og_db,
+                    id=og_db_id,
+            ):
                 issue_action = 'edit'
             else:
                 issue_action = 'add'


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Some items would not properly show "edit" when they were provided by ThemerrDB. This was due to not being able to detect if the item exists in ThemerrDB after the logic was changed in #209.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
