### PR TITLE
fix: disable Plex plugin framework sandbox and add back all missing builtins

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -25,17 +25,20 @@ else:  # the code is running outside of Plex
 # imports from Libraries\Shared
 from typing import Optional
 
-# get the original Python builtins module
-python_builtins = inspect.getmodule(object)
+try:
+    # get the original Python builtins module
+    python_builtins = inspect.getmodule(object)
 
-# get the Sandbox instance
-sandbox = inspect.stack()[1][0].f_locals["self"]
+    # get the Sandbox instance
+    sandbox = inspect.stack()[1][0].f_locals["self"]
 
-# bypass RestrictedPython
-getattr(sandbox, "_core").loader.compile = lambda src, name, _=False: python_builtins.compile(src, name, "exec")
+    # bypass RestrictedPython
+    getattr(sandbox, "_core").loader.compile = lambda src, name, _=False: python_builtins.compile(src, name, "exec")
 
-# restore Python builtins
-sandbox.environment.update(python_builtins.vars(python_builtins))
+    # restore Python builtins
+    sandbox.environment.update(python_builtins.vars(python_builtins))
+except Exception as e:
+    Log.Exception("Failed to bypass RestrictedPython: {}".format(e))
 
 # local imports
 from default_prefs import default_prefs

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # standard imports
+import inspect
 import re
 
 # plex debugging
@@ -23,6 +24,18 @@ else:  # the code is running outside of Plex
 
 # imports from Libraries\Shared
 from typing import Optional
+
+# get the original Python builtins module
+python_builtins = inspect.getmodule(object)
+
+# get the Sandbox instance
+sandbox = inspect.stack()[1][0].f_locals["self"]
+
+# bypass RestrictedPython
+getattr(sandbox, "_core").loader.compile = lambda src, name, _=False: python_builtins.compile(src, name, "exec")
+
+# restore Python builtins
+sandbox.environment.update(python_builtins.vars(python_builtins))
 
 # local imports
 from default_prefs import default_prefs


### PR DESCRIPTION

## Description
<!--- Please include a summary of the changes. --->
title

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
