### PR TITLE
feat: migrate from previous versions

### DIFF
--- a/Contents/Code/default_prefs.py
+++ b/Contents/Code/default_prefs.py
@@ -20,5 +20,6 @@ default_prefs = dict(
     enum_webapp_locale='en',
     str_webapp_http_host='0.0.0.0',
     int_webapp_http_port='9494',
-    bool_webapp_log_werkzeug_messages='False'
+    bool_webapp_log_werkzeug_messages='False',
+    bool_migrate_locked_themes='False',
 )

--- a/Contents/Code/migration_helper.py
+++ b/Contents/Code/migration_helper.py
@@ -1,0 +1,252 @@
+# -*- coding: utf-8 -*-
+
+# standard imports
+import json
+import os
+from threading import Lock
+
+# plex debugging
+try:
+    import plexhints  # noqa: F401
+except ImportError:
+    pass
+else:  # the code is running outside of Plex
+    from plexhints.core_kit import Core  # core kit
+    from plexhints.log_kit import Log  # log kit
+
+# imports from Libraries\Shared
+from requests.exceptions import ReadTimeout
+from typing import Optional
+
+# local imports
+from constants import themerr_data_directory
+import plex_api_helper
+
+
+class MigrationHelper:
+    """
+    Helper class to perform migrations.
+
+    Attributes
+    ----------
+    migration_status_file : str
+        The path to the migration status file.
+    migration_status_file_lock : Lock
+        The lock for the migration status file.
+
+    Methods
+    -------
+    _validate_migration_key(key, raise_exception=False)
+        Validate the given migration key.
+    get_migration_status(key)
+        Get the migration status for the given key.
+    set_migration_status(key)
+        Update the migration status file.
+    perform_migration(key)
+        Perform the migration for the given key, if it has not already been performed.
+    migrate_locked_themes()
+        Unlock all locked themes.
+    """
+    # Define the migration keys as class attributes for dot notation access
+    LOCKED_THEMES = 'locked_themes'
+
+    def __init__(self):
+        self.migration_status_file = os.path.join(themerr_data_directory, 'migration_status.json')
+        self.migration_status_file_lock = Lock()
+
+        # Map keys to their respective functions
+        self.migration_functions = {
+            self.LOCKED_THEMES: self.migrate_locked_themes,
+        }
+
+    def _validate_migration_key(self, key, raise_exception=False):
+        # type: (str, bool) -> bool
+        """
+        Validate the given migration key.
+
+        Ensure the given key has a corresponding class attribute and function.
+
+        Parameters
+        ----------
+        key : str
+            The key to validate.
+        raise_exception : bool
+            Whether to raise an exception if the key is invalid.
+
+        Returns
+        -------
+        bool
+            Whether the key is valid.
+
+        Raises
+        ------
+        AttributeError
+            If the key is invalid and raise_exception is True.
+        """
+        # Ensure the key is a class attribute
+        upper_key = key.upper()
+        if not hasattr(self, upper_key):
+            Log.Error('{} key is not a class attribute'.format(upper_key))
+            if raise_exception:
+                raise AttributeError('{} key is not a class attribute'.format(upper_key))
+            return False
+
+        # ensure the class attribute value is the same and lowercase
+        if getattr(self, upper_key) != key:
+            Log.Error('{} key is not the same as the class attribute value'.format(key))
+            if raise_exception:
+                raise AttributeError('{} key is not the same as the class attribute value'.format(key))
+            return False
+
+        # Ensure the key has a corresponding function
+        if not self.migration_functions.get(key):
+            Log.Error('{} key does not have a corresponding function'.format(key))
+            if raise_exception:
+                raise AttributeError('{} key does not have a corresponding function'.format(key))
+            return False
+
+        # if we made it this far, the key is valid
+        return True
+
+    def get_migration_status(self, key):
+        # type: (str) -> Optional[bool]
+        """
+        Get the migration status for the given key.
+
+        Parameters
+        ----------
+        key : str
+            The key to get the migration status for.
+
+        Returns
+        -------
+        Optional[bool]
+            The migration status for the given key, or None if the key is not found.
+
+        Examples
+        --------
+        >>> MigrationHelper().get_migration_status(key=self.LOCKED_THEMES)
+        True
+        """
+        # validate
+        self._validate_migration_key(key=key, raise_exception=True)
+
+        with self.migration_status_file_lock:
+            if os.path.isfile(self.migration_status_file):
+                migration_status = json.loads(
+                    s=str(Core.storage.load(filename=self.migration_status_file, binary=False)))
+            else:
+                migration_status = {}
+
+        return migration_status.get(key)
+
+    def set_migration_status(self, key):
+        # type: (str) -> None
+        """
+        Update the migration status file.
+
+        Parameters
+        ----------
+        key : str
+            The key to update in the migration status file.
+
+        Examples
+        --------
+        >>> MigrationHelper().set_migration_status(key=self.LOCKED_THEMES)
+        """
+        # validate
+        self._validate_migration_key(key=key, raise_exception=True)
+
+        Log.Debug('Updating migration status file: {}'.format(key))
+        with self.migration_status_file_lock:
+            if os.path.isfile(self.migration_status_file):
+                migration_status = json.loads(
+                    s=str(Core.storage.load(filename=self.migration_status_file, binary=False)))
+            else:
+                migration_status = {}
+
+            if not migration_status.get(key):
+                migration_status[key] = True
+                Core.storage.save(filename=self.migration_status_file, data=json.dumps(migration_status), binary=False)
+
+    @staticmethod
+    def migrate_locked_themes():
+        """
+        Unlock all locked themes.
+
+        Prior to v0.3.0, themes uploaded by Themerr-plex were locked which leads to an issue in v0.3.0 and newer, since
+        Themerr-plex will not update locked themes. Additionally, there was no way to know if a theme was added by
+        Themerr-plex or not until v0.3.0, so this migration will unlock all themes.
+        """
+        plex = plex_api_helper.setup_plexapi()
+
+        plex_library = plex.library
+
+        sections = plex_library.sections()
+
+        # never update this list, it needs to match what was available before v0.3.0
+        contributes_to = (
+            'tv.plex.agents.movie',
+            'com.plexapp.agents.imdb',
+            'com.plexapp.agents.themoviedb',
+            'dev.lizardbyte.retroarcher-plex'
+        )
+
+        for section in sections:
+            if section.agent not in contributes_to:
+                continue  # skip items with unsupported metadata agents for < v0.3.0
+
+            field = 'theme'
+
+            # not sure if this unlocks themes for collections
+            try:
+                section.unlockAllField(field=field, libtype='movie')
+            except ReadTimeout:
+                # this may timeout, but no big deal, we can just unlock the items individually
+                Log.Warn('ReadTimeout occurred while unlocking all themes for section: {}, will fallback to '
+                         'individual item unlocking'.format(section.title))
+
+            # get all the items in the section
+            media_items = section.all()  # this is redundant, assuming unlockAllField() works on movies
+
+            # collections were added in v0.3.0, but collect them as well for anyone who may have used a nightly build
+            # get all collections in the section
+            collections = section.collections()
+
+            # combine the items and collections into one list
+            # this is done so that we can process both items and collections in the same loop
+            all_items = media_items + collections
+
+            for item in all_items:
+                if item.isLocked(field=field):
+                    plex_api_helper.change_lock_status(item=item, field=field, lock=False)
+
+    def perform_migration(self, key):
+        # type: (str) -> None
+        """
+        Perform the migration for the given key, if it has not already been performed.
+
+        Parameters
+        ----------
+        key : str
+            The key to perform the migration for.
+
+        Examples
+        --------
+        >>> MigrationHelper().perform_migration(key=MigrationHelper.LOCKED_THEMES)
+        """
+        # validate
+        self._validate_migration_key(key=key, raise_exception=True)
+
+        # check if the migration has already been performed
+        migration_status = self.get_migration_status(key=key)
+        if migration_status:
+            Log.Debug('Skipping "{}" migration, already completed.'.format(key))
+            return
+
+        # Use the dictionary to find and call the corresponding function
+        migration_function = self.migration_functions.get(key)
+        migration_function()
+
+        # update the migration status file
+        self.set_migration_status(key)

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -147,5 +147,12 @@
 		"label": "Log all web server messages (requires Plex Media Server restart)",
 		"default": "False",
 		"secure": "false"
+	},
+	{
+		"id": "bool_migrate_locked_themes",
+		"type": "bool",
+		"label": "Migrate from < v0.3.0 (If you used Themerr before v0.3.0, set this to True)",
+		"default": "False",
+		"secure": "false"
 	}
 ]

--- a/docs/source/about/usage.rst
+++ b/docs/source/about/usage.rst
@@ -279,3 +279,18 @@ Description
 
 Default
    ``False``
+
+Migrate from < v0.3.0
+^^^^^^^^^^^^^^^^^^^^^
+
+Description
+   Prior to v0.3.0, Themerr-plex uploaded themes were locked and there was no way to determine if a theme was supplied
+   by Themerr-plex. Therefore, if you used Themerr-plex prior to v0.3.0, you will need to enable this setting to
+   automatically unlock all existing themes (for agents that Themerr-plex supports). Once the migration has completed,
+   the unlock function will never run again.
+
+   If you see many of the ``Unknown provider`` status in the web UI, it is a good indication that you need to enable
+   this option, unless you have many themes provided by other tools.
+
+Default
+   ``False``

--- a/docs/source/code_docs/migration_helper.rst
+++ b/docs/source/code_docs/migration_helper.rst
@@ -1,0 +1,12 @@
+:github_url: https://github.com/LizardByte/Themerr-plex/tree/nightly/Contents/Code/migration_helper.py
+
+.. include:: ../global.rst
+
+:modname:`migration_helper`
+---------------------------
+.. automodule:: Code.migration_helper
+    :members:
+    :inherited-members:
+    :private-members:
+    :show-inheritance:
+    :undoc-members:

--- a/docs/source/toc.rst
+++ b/docs/source/toc.rst
@@ -26,6 +26,7 @@
    code_docs/main
    code_docs/general_helper
    code_docs/lizardbyte_db_helper
+   code_docs/migration_helper
    code_docs/plex_api_helper
    code_docs/scheduled_tasks
    code_docs/tmdb_helper

--- a/tests/unit/test_migration_helper.py
+++ b/tests/unit/test_migration_helper.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+
+# standard imports
+import os
+
+# lib imports
+import pytest
+
+# local imports
+from Code import migration_helper
+from Code import plex_api_helper
+
+migration_helper_object = migration_helper.MigrationHelper()
+
+
+@pytest.fixture(scope='function')
+def migration_helper_fixture():
+    return migration_helper_object
+
+
+@pytest.fixture(scope='function')
+def migration_status_file(migration_helper_fixture):
+    migration_status_file = migration_helper_fixture.migration_status_file
+
+    # delete the migration status file if it exists
+    if os.path.isfile(migration_status_file):
+        os.remove(migration_status_file)
+
+    # yield the migration status file
+    yield
+
+    # delete the migration status file if it exists
+    if os.path.isfile(migration_status_file):
+        os.remove(migration_status_file)
+
+
+@pytest.mark.parametrize('key, raise_exception, expected_return, expected_raise', [
+    (migration_helper_object.LOCKED_THEMES, False, True, None),
+    (migration_helper_object.LOCKED_THEMES, True, True, None),
+    ('invalid', False, False, None),
+    ('invalid', True, False, AttributeError),
+])
+def test_validate_migration_key(migration_helper_fixture, key, raise_exception, expected_return, expected_raise):
+    if expected_raise is not None:
+        with pytest.raises(expected_raise):
+            migration_helper_fixture._validate_migration_key(key=key, raise_exception=raise_exception)
+    else:
+        validated = migration_helper_fixture._validate_migration_key(key=key, raise_exception=raise_exception)
+        assert validated == expected_return, 'Expected {} but got {}'.format(expected_return, validated)
+
+
+@pytest.mark.parametrize('key, expected', [
+    (migration_helper_object.LOCKED_THEMES, None),
+    pytest.param('invalid', None, marks=pytest.mark.xfail(raises=AttributeError)),
+])
+def test_get_migration_status(migration_helper_fixture, migration_status_file, key, expected):
+    migration_status = migration_helper_fixture.get_migration_status(key=key)
+    assert migration_status == expected, 'Expected {} but got {}'.format(expected, migration_status)
+
+
+@pytest.mark.parametrize('key', [
+    migration_helper_object.LOCKED_THEMES,
+    pytest.param('invalid', marks=pytest.mark.xfail(raises=AttributeError)),
+])
+def test_set_migration_status(migration_helper_fixture, migration_status_file, key):
+    # perform the test twice, to load an existing migration file
+    for _ in range(2):
+        migration_helper_fixture.set_migration_status(key=key)
+        migration_status = migration_helper_fixture.get_migration_status(key=key)
+        assert migration_status is True, 'Migration status was not set to True'
+
+
+@pytest.mark.parametrize('key', [
+    migration_helper_object.LOCKED_THEMES,
+])
+def test_perform_migration(migration_helper_fixture, migration_status_file, key):
+    # perform the migration twice, should return early on the second run
+    for _ in range(2):
+        migration_helper_fixture.perform_migration(key=key)
+        migration_status = migration_helper_fixture.get_migration_status(key=key)
+        assert migration_status is True, 'Migration status was not set to True'
+
+
+def test_migrate_locked_themes(movies):
+    field = 'theme'
+
+    # lock all is not working
+    # movies.lockAllField(field=field, libtype='movie')
+    # movies.reload()
+
+    for movie in movies.all():
+        plex_api_helper.change_lock_status(item=movie, field=field, lock=True)
+        assert movie.isLocked(field=field) is True, '{} for movie is not locked'.format(field)
+
+    migration_helper_object.migrate_locked_themes()
+    movies.reload()
+
+    for movie in movies.all():
+        assert movie.isLocked(field=field) is False, '{} for movie is still locked'.format(field)

--- a/tests/unit/test_plex_api_helper.py
+++ b/tests/unit/test_plex_api_helper.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+# lib imports
+import pytest
+
+# local imports
+from Code import plex_api_helper
+
+
+def test_all_themes_unlocked(movies):
+    field = 'theme'
+    for item in movies.all():
+        assert not item.isLocked(field=field)
+
+
+@pytest.mark.parametrize('lock', [
+    False,  # verify the function pre-checks are working
+    True,  # verify changing the lock status to True works
+    False,  # verify changing the lock status to False works
+])
+def test_change_lock_status(movies, lock):
+    field = 'theme'
+    for item in movies.all():
+        change_status = plex_api_helper.change_lock_status(item, field=field, lock=lock)
+        assert change_status, 'change_lock_status did not return True'
+        assert item.isLocked(field=field) == lock, 'Failed to change lock status to {}'.format(lock)


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Add a method to migrate from previous versions. A use case for this is when upgrading from v0.2 to v0.3.0, themes previously added by Themerr will not be known to be added by Themerr... and they are also locked so those themes will never be updated.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
