### PR TITLE
fix(plexapi): fix random _strptime import errors

### DIFF
--- a/Contents/Code/plex_api_helper.py
+++ b/Contents/Code/plex_api_helper.py
@@ -35,6 +35,9 @@ import themerr_db_helper
 import tmdb_helper
 from youtube_dl_helper import process_youtube
 
+# fix random _strptime import bug in plexapi
+import _strptime  # noqa: F401
+
 plex_server = None
 
 q = queue.Queue()


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
There are random bugs with importing `_strptime` in plexapi... detected in CI tests.

```txt
2023-12-02 02:14:30,926 (7fd1a97dbb38) :  CRITICAL (plex_api_helper:551) - Unexpected error processing rating key: 2, error: Failed to import _strptime because the import lockis held by another thread. (most recent call last):
  File "/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Plug-ins/Themerr-plex.bundle/Contents/Code/plex_api_helper.py", line 549, in process_queue
    update_plex_item(rating_key=rating_key)  # process that rating_key
  File "/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Plug-ins/Themerr-plex.bundle/Contents/Code/plex_api_helper.py", line 115, in update_plex_item
    item = get_plex_item(rating_key=rating_key)
  File "/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Plug-ins/Themerr-plex.bundle/Contents/Code/plex_api_helper.py", line 529, in get_plex_item
    item = plex.fetchItem(ekey=rating_key)
  File "/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Plug-ins/Themerr-plex.bundle/Contents/Libraries/Shared/plexapi/base.py", line 314, in fetchItem
    return self.fetchItems(ekey, cls, **kwargs)[0]
  File "/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Plug-ins/Themerr-plex.bundle/Contents/Libraries/Shared/plexapi/base.py", line 263, in fetchItems
    subresults = self.findItems(data, cls, ekey, **kwargs)
  File "/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Plug-ins/Themerr-plex.bundle/Contents/Libraries/Shared/plexapi/base.py", line 336, in findItems
    item = self._buildItemOrNone(elem, cls, initpath)
  File "/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Plug-ins/Themerr-plex.bundle/Contents/Libraries/Shared/plexapi/base.py", line 116, in _buildItemOrNone
    return self._buildItem(elem, cls, initpath)
  File "/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Plug-ins/Themerr-plex.bundle/Contents/Libraries/Shared/plexapi/base.py", line 108, in _buildItem
    return ecls(self._server, elem, initpath)
  File "/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Plug-ins/Themerr-plex.bundle/Contents/Libraries/Shared/plexapi/base.py", line 69, in __init__
    self._loadData(data)
  File "/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Plug-ins/Themerr-plex.bundle/Contents/Libraries/Shared/plexapi/video.py", line 391, in _loadData
    self.originallyAvailableAt = utils.toDatetime(data.attrib.get('originallyAvailableAt'), '%Y-%m-%d')
  File "/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Plug-ins/Themerr-plex.bundle/Contents/Libraries/Shared/plexapi/utils.py", line 328, in toDatetime
    return datetime.strptime(value, format)
ImportError: Failed to import _strptime because the import lockis held by another thread.

```

```txt
2023-12-02 02:28:16,520 (7f00248a4b38) :  CRITICAL (plex_api_helper:551) - Unexpected error processing rating key: 1, error: 'module' object has no attribute '_strptime' (most recent call last):
  File "/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Plug-ins/Themerr-plex.bundle/Contents/Code/plex_api_helper.py", line 549, in process_queue
    update_plex_item(rating_key=rating_key)  # process that rating_key
  File "/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Plug-ins/Themerr-plex.bundle/Contents/Code/plex_api_helper.py", line 115, in update_plex_item
    item = get_plex_item(rating_key=rating_key)
  File "/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Plug-ins/Themerr-plex.bundle/Contents/Code/plex_api_helper.py", line 529, in get_plex_item
    item = plex.fetchItem(ekey=rating_key)
  File "/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Plug-ins/Themerr-plex.bundle/Contents/Libraries/Shared/plexapi/base.py", line 314, in fetchItem
    return self.fetchItems(ekey, cls, **kwargs)[0]
  File "/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Plug-ins/Themerr-plex.bundle/Contents/Libraries/Shared/plexapi/base.py", line 263, in fetchItems
    subresults = self.findItems(data, cls, ekey, **kwargs)
  File "/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Plug-ins/Themerr-plex.bundle/Contents/Libraries/Shared/plexapi/base.py", line 336, in findItems
    item = self._buildItemOrNone(elem, cls, initpath)
  File "/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Plug-ins/Themerr-plex.bundle/Contents/Libraries/Shared/plexapi/base.py", line 116, in _buildItemOrNone
    return self._buildItem(elem, cls, initpath)
  File "/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Plug-ins/Themerr-plex.bundle/Contents/Libraries/Shared/plexapi/base.py", line 108, in _buildItem
    return ecls(self._server, elem, initpath)
  File "/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Plug-ins/Themerr-plex.bundle/Contents/Libraries/Shared/plexapi/base.py", line 69, in __init__
    self._loadData(data)
  File "/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Plug-ins/Themerr-plex.bundle/Contents/Libraries/Shared/plexapi/video.py", line 391, in _loadData
    self.originallyAvailableAt = utils.toDatetime(data.attrib.get('originallyAvailableAt'), '%Y-%m-%d')
  File "/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Plug-ins/Themerr-plex.bundle/Contents/Libraries/Shared/plexapi/utils.py", line 328, in toDatetime
    return datetime.strptime(value, format)
AttributeError: 'module' object has no attribute '_strptime'

```


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
