### PR TITLE
fix(ui): fix collapse issue with libraries that contain spaces in the name

### DIFF
--- a/Contents/Code/webapp.py
+++ b/Contents/Code/webapp.py
@@ -229,6 +229,7 @@ def cache_data():
 
         # add each section to the items dict
         items[section.key] = dict(
+            key=section.key,
             title=section.title,
             agent=section.agent,
             items=[],

--- a/Contents/Resources/web/templates/home.html
+++ b/Contents/Resources/web/templates/home.html
@@ -15,17 +15,17 @@
 
         {% for section in items %}
         <!-- Library sections -->
-        <section class="py-5 offset-anchor" id="{{ items[section]['title'] }}">
+        <section class="py-5 offset-anchor" id="section_{{ items[section]['key'] }}">
             <div class="row">
                 <div class="col-12 d-flex justify-content-between align-items-center">
                     <!-- Section title -->
                     <h1 class="text-white">{{ items[section]['title'] }}</h1>
                     <!-- Collapse/Expand button -->
                     <h2><a class="text-black" role="button" data-bs-toggle="collapse"
-                           data-bs-target="#{{ items[section]['title'] }}_collapse" aria-expanded="false"
-                           aria-controls="{{ items[section]['title'] }}_collapse"
+                           data-bs-target="#section_{{ items[section]['key'] }}_collapse" aria-expanded="false"
+                           aria-controls="section_{{ items[section]['key'] }}_collapse"
                            onclick="toggleArrow(this)">
-                           <i class="text-white fas fa-caret-up" id="{{ items[section]['title'] }}_arrow"></i>
+                           <i class="text-white fas fa-caret-up" id="section_{{ items[section]['key'] }}_arrow"></i>
                     </a></h2>
                 </div>
             </div>
@@ -90,7 +90,7 @@
             <!-- table -->
             <div class="row">
                 <div class="col-12">
-                    <div class="collapse show" id="{{ items[section]['title'] }}_collapse">
+                    <div class="collapse show" id="section_{{ items[section]['key'] }}_collapse">
                         <table class="table table-sm table-bordered border-dark caption-top">
                             <caption>{{ items[section]['title'] }}</caption>
                             <tr class="d-flex table-dark">


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR fixes an issue where libraries with spaces in the name could not collapse in the WebUI. Users will need to wait until the database cache refreshes before the collapse/expand buttons will work properly.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes #255 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
