### PR TITLE
fix(dashboard): fix issue where local items could prevent ui cache from completing

### DIFF
--- a/Contents/Code/webapp.py
+++ b/Contents/Code/webapp.py
@@ -260,13 +260,10 @@ def cache_data():
             og_db = database
             og_db_id = database_id
 
-            try:
-                year = item.year
-            except AttributeError:
-                year = None
+            year = getattr(item, 'year', None)
 
             # convert imdb id to tmdb id, so we can build the issue url properly
-            if item.type == 'movie' and (
+            if item.type == 'movie' and database_id and (
                     item_agent == 'com.plexapp.agents.imdb'
                     or database_id.startswith('tt')
             ):
@@ -276,28 +273,28 @@ def cache_data():
 
             item_issue_url = None
 
-            try:
-                issue_url = issue_urls[database_type]
-            except KeyError:
-                issue_url = None
+            issue_url = issue_urls.get(database_type)
 
             if issue_url:
                 if item.type == 'movie':
                     # override the id since ThemerrDB issues require the slug as part of the url
                     if item_agent == 'dev.lizardbyte.retroarcher-plex':
-                        # get the slug and name from LizardByte db
-                        try:
-                            db_data = JSON.ObjectFromURL(
-                                url='https://db.lizardbyte.dev/games/{}.json'.format(database_id),
-                                cacheTime=CACHE_1DAY,
-                                errors='strict'
-                            )
-                            issue_title = '{} ({})'.format(db_data['name'], year)
-                            database_id = db_data['slug']
-                        except Exception as e:
-                            Log.Error('Error getting game data from LizardByte db: {}'.format(e))
-                            issue_title = '{} ({})'.format(item.title, year)
-                            database_id = None
+                        issue_title = '{} ({})'.format(item.title, year)
+
+                        if database_id:
+                            # get the slug and name from LizardByte db
+                            try:
+                                db_data = JSON.ObjectFromURL(
+                                    url='https://db.lizardbyte.dev/games/{}.json'.format(database_id),
+                                    cacheTime=CACHE_1DAY,
+                                    errors='strict'
+                                )
+                            except Exception as e:
+                                Log.Error('Error getting game data from LizardByte db: {}'.format(e))
+                                database_id = None
+                            else:
+                                issue_title = '{} ({})'.format(db_data['name'], year)
+                                database_id = db_data['slug']
                     else:
                         issue_title = '{} ({})'.format(getattr(item, "originalTitle", None) or item.title, year)
                 else:  # collections
@@ -305,19 +302,20 @@ def cache_data():
 
                     # override the id since ThemerrDB issues require the slug as part of the url
                     if item_agent == 'dev.lizardbyte.retroarcher-plex':
-                        # get the slug and name from LizardByte db
-                        try:
-                            db_data = JSON.ObjectFromURL(
-                                url='https://db.lizardbyte.dev/{}/all.json'.format(
-                                    database_type.rsplit('_', 1)[-1]),
-                                cacheTime=CACHE_1DAY,
-                                errors='strict'
-                            )
-                            issue_title = db_data[str(database_id)]['name']
-                            database_id = db_data[str(database_id)]['slug']
-                        except Exception as e:
-                            Log.Error('Error getting collection data from LizardByte db: {}'.format(e))
-                            database_id = None
+                        if database_id:
+                            # get the slug and name from LizardByte db
+                            try:
+                                db_data = JSON.ObjectFromURL(
+                                    url='https://db.lizardbyte.dev/{}/all.json'.format(
+                                        database_type.rsplit('_', 1)[-1]),
+                                    cacheTime=CACHE_1DAY,
+                                    errors='strict'
+                                )
+                                issue_title = db_data[str(database_id)]['name']
+                                database_id = db_data[str(database_id)]['slug']
+                            except Exception as e:
+                                Log.Error('Error getting collection data from LizardByte db: {}'.format(e))
+                                database_id = None
 
                 if database_id:
                     # url encode the issue title
@@ -325,7 +323,7 @@ def cache_data():
 
                     item_issue_url = issue_url.format(issue_title, database_id)
 
-            if database_type and themerr_db_helper.item_exists(
+            if database_type and og_db and og_db_id and themerr_db_helper.item_exists(
                     database_type=database_type,
                     database=og_db,
                     id=og_db_id,


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
The dashboard could fail to cache if a local item with no database id was present in any section.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
