### PR TITLE
fix(legacy agents): do not upload themes unless Themerr is enabled

### DIFF
--- a/Contents/Code/constants.py
+++ b/Contents/Code/constants.py
@@ -62,6 +62,18 @@ metadata_type_map = dict(
     show='TV Shows'
 )
 
+# the explicit IPv4 address is used because `localhost` can resolve to ::1, which `websocket` rejects
+plex_url = 'http://127.0.0.1:32400'
+plex_token = os.environ.get('PLEXTOKEN')
+
+plex_section_type_settings_map = dict(
+    album=9,
+    artist=8,
+    movie=1,
+    photo=13,
+    show=2,
+)
+
 # issue url constants
 base_url = 'https://github.com/LizardByte/ThemerrDB/issues/new?assignees='
 issue_label = 'request-theme'

--- a/tests/unit/test_general_helper.py
+++ b/tests/unit/test_general_helper.py
@@ -12,6 +12,29 @@ from Code import constants
 from Code import general_helper
 
 
+@pytest.mark.parametrize('item_agent, item_type, expected', [
+    ('com.plexapp.agents.imdb', 'movie', True),
+    ('com.plexapp.agents.themoviedb', 'movie', True),
+    # ('com.plexapp.agents.themoviedb', 'show', True),
+    # ('com.plexapp.agents.thetvdb', 'show', True),
+])
+def test_agent_enabled(item_agent, item_type, expected):
+    assert general_helper.agent_enabled(item_agent=item_agent, item_type=item_type) is expected
+
+
+@pytest.mark.parametrize('item_agent, item_type, expected', [
+    ('tv.plex.agents.movie', 'movie', True),
+    ('com.plexapp.agents.imdb', 'movie', True),
+    ('com.plexapp.agents.themoviedb', 'movie', True),
+    # ('tv.plex.agents.series', 'show', True),
+    # ('com.plexapp.agents.themoviedb', 'show', True),
+    # ('com.plexapp.agents.thetvdb', 'show', True),
+    ('invalid', 'invalid', False),
+])
+def test_continue_update(item_agent, item_type, expected):
+    assert general_helper.continue_update(item_agent=item_agent, item_type=item_type) is expected
+
+
 def test_get_media_upload_path(movies):
     test_items = [
         movies.all()[0]


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Plex runs the Themerr agent even if it is disabled in the agent menu. Due to how we add theme songs using the API (instead of the plugin framework), we need to perform a check to see if we should add the theme or not.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
