### PR TITLE
fix(collections): add migration for collection metadata

### DIFF
--- a/Contents/Code/default_prefs.py
+++ b/Contents/Code/default_prefs.py
@@ -22,4 +22,5 @@ default_prefs = dict(
     int_webapp_http_port='9494',
     bool_webapp_log_werkzeug_messages='False',
     bool_migrate_locked_themes='False',
+    bool_migrate_locked_collection_fields='False',
 )

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -151,7 +151,14 @@
 	{
 		"id": "bool_migrate_locked_themes",
 		"type": "bool",
-		"label": "Migrate from < v0.3.0 (If you used Themerr before v0.3.0, set this to True)",
+		"label": "Migrate themes from < v0.3.0 (If you used Themerr before v0.3.0, set this to True)",
+		"default": "False",
+		"secure": "false"
+	},
+	{
+		"id": "bool_migrate_locked_collection_fields",
+		"type": "bool",
+		"label": "Migrate collection metadata from < v0.3.0 (If you used Themerr before v0.3.0, set this to True)",
 		"default": "False",
 		"secure": "false"
 	}

--- a/docs/source/about/usage.rst
+++ b/docs/source/about/usage.rst
@@ -294,3 +294,28 @@ Description
 
 Default
    ``False``
+
+Migrate themes from < v0.3.0
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Description
+   Prior to v0.3.0, Themerr-plex uploaded themes were locked and there was no way to determine if a theme was supplied
+   by Themerr-plex. Therefore, if you used Themerr-plex prior to v0.3.0, you will need to enable this setting to
+   automatically unlock all existing themes (for agents that Themerr-plex supports). Once the migration has completed,
+   the unlock function will never run again.
+
+   If you see many of the ``Unknown provider`` status in the web UI, it is a good indication that you need to enable
+   this option, unless you have many themes provided by other tools.
+
+Default
+   ``False``
+
+Migrate collection metadata from < v0.3.0
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Description
+   Prior to v0.3.0, fields for collections modified by Themerr-plex were locked which leads to an issue in v0.3.0
+   and newer, since Themerr-plex will not update locked fields.
+
+Default
+   ``False``

--- a/tests/unit/test_migration_helper.py
+++ b/tests/unit/test_migration_helper.py
@@ -37,6 +37,8 @@ def migration_status_file(migration_helper_fixture):
 @pytest.mark.parametrize('key, raise_exception, expected_return, expected_raise', [
     (migration_helper_object.LOCKED_THEMES, False, True, None),
     (migration_helper_object.LOCKED_THEMES, True, True, None),
+    (migration_helper_object.LOCKED_COLLECTION_FIELDS, False, True, None),
+    (migration_helper_object.LOCKED_COLLECTION_FIELDS, True, True, None),
     ('invalid', False, False, None),
     ('invalid', True, False, AttributeError),
 ])
@@ -51,6 +53,7 @@ def test_validate_migration_key(migration_helper_fixture, key, raise_exception, 
 
 @pytest.mark.parametrize('key, expected', [
     (migration_helper_object.LOCKED_THEMES, None),
+    (migration_helper_object.LOCKED_COLLECTION_FIELDS, None),
     pytest.param('invalid', None, marks=pytest.mark.xfail(raises=AttributeError)),
 ])
 def test_get_migration_status(migration_helper_fixture, migration_status_file, key, expected):
@@ -60,6 +63,7 @@ def test_get_migration_status(migration_helper_fixture, migration_status_file, k
 
 @pytest.mark.parametrize('key', [
     migration_helper_object.LOCKED_THEMES,
+    migration_helper_object.LOCKED_COLLECTION_FIELDS,
     pytest.param('invalid', marks=pytest.mark.xfail(raises=AttributeError)),
 ])
 def test_set_migration_status(migration_helper_fixture, migration_status_file, key):
@@ -72,6 +76,7 @@ def test_set_migration_status(migration_helper_fixture, migration_status_file, k
 
 @pytest.mark.parametrize('key', [
     migration_helper_object.LOCKED_THEMES,
+    migration_helper_object.LOCKED_COLLECTION_FIELDS,
 ])
 def test_perform_migration(migration_helper_fixture, migration_status_file, key):
     # perform the migration twice, should return early on the second run
@@ -97,3 +102,21 @@ def test_migrate_locked_themes(movies):
 
     for movie in movies.all():
         assert movie.isLocked(field=field) is False, '{} for movie is still locked'.format(field)
+
+
+@pytest.mark.parametrize('field', [
+    'art',
+    'summary',
+    'thumb',
+])
+def test_migrate_locked_collection_fields(field, movies):
+    # lock all is not working, so lock manually
+    for item in movies.collections():
+        plex_api_helper.change_lock_status(item=item, field=field, lock=True)
+        assert item.isLocked(field=field) is True, '{} for collection is not locked'.format(field)
+
+    migration_helper_object.migrate_locked_collection_fields()
+    movies.reload()
+
+    for item in movies.collections():
+        assert item.isLocked(field=field) is False, '{} for collection is still locked'.format(field)


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR adds a migration option to unlock fields locked for collections prior to v0.3.0. It only unlocks fields for collections with a theme song.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
