### PR TITLE
feat: add option to ignore locked fields

### DIFF
--- a/Contents/Code/default_prefs.py
+++ b/Contents/Code/default_prefs.py
@@ -23,4 +23,5 @@ default_prefs = dict(
     bool_webapp_log_werkzeug_messages='False',
     bool_migrate_locked_themes='False',
     bool_migrate_locked_collection_fields='False',
+    bool_ignore_locked_fields='False',
 )

--- a/Contents/Code/plex_api_helper.py
+++ b/Contents/Code/plex_api_helper.py
@@ -166,7 +166,7 @@ def update_plex_item(rating_key):
                         else:
                             add_media(item=item, media_type='art', media_url_id=data['backdrop_path'], media_url=url)
                         # update summary
-                        if item.isLocked(field='summary'):
+                        if item.isLocked(field='summary') and not Prefs['bool_ignore_locked_fields']:
                             Log.Debug('Not overwriting locked summary for collection: {}'.format(item.title))
                         else:
                             try:
@@ -181,7 +181,7 @@ def update_plex_item(rating_key):
                                     except Exception as e:
                                         Log.Error('{}: Error updating summary: {}'.format(item.ratingKey, e))
 
-                if item.isLocked(field='theme'):
+                if item.isLocked(field='theme') and not Prefs['bool_ignore_locked_fields']:
                     Log.Debug('Not overwriting locked theme for {}: {}'.format(item.type, item.title))
                 else:
                     # get youtube_url
@@ -250,7 +250,7 @@ def add_media(item, media_type, media_url_id, media_file=None, media_url=None):
     settings_hash = general_helper.get_themerr_settings_hash()
     themerr_data = general_helper.get_themerr_json_data(item=item)
 
-    if item.isLocked(field=media_type_dict[media_type]['plex_field']):
+    if item.isLocked(field=media_type_dict[media_type]['plex_field']) and not Prefs['bool_ignore_locked_fields']:
         Log.Info('Not overwriting locked "{}" for {}: {}'.format(
             media_type_dict[media_type]['name'], item.type, item.title
         ))

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -161,5 +161,12 @@
 		"label": "Migrate collection metadata from < v0.3.0 (If you used Themerr before v0.3.0, set this to True)",
 		"default": "False",
 		"secure": "false"
+	},
+	{
+		"id": "bool_ignore_locked_fields",
+		"type": "bool",
+		"label": "Ignore locked fields (Always upload media, even if fields are locked)",
+		"default": "False",
+		"secure": "false"
 	}
 ]

--- a/docs/source/about/usage.rst
+++ b/docs/source/about/usage.rst
@@ -319,3 +319,12 @@ Description
 
 Default
    ``False``
+
+Ignore locked fields
+^^^^^^^^^^^^^^^^^^^^
+
+Description
+   When enabled, Themerr-plex will ignore locked fields when updating themes and collection metadata.
+
+Default
+   ``False``


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR adds an option to completely ignore locked fields when adding themes or collection metadata.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
