### PR TITLE
fix(tasks): ensure ui can be cached if auto update items is disabled

### DIFF
--- a/Contents/Code/scheduled_tasks.py
+++ b/Contents/Code/scheduled_tasks.py
@@ -113,9 +113,10 @@ def setup_scheduling():
             job_func=run_threaded,
             target=scheduled_update
         )
-        schedule.every(max(15, int(Prefs['int_update_database_cache_interval']))).minutes.do(
-            job_func=run_threaded,
-            target=cache_data
-        )
+
+    schedule.every(max(15, int(Prefs['int_update_database_cache_interval']))).minutes.do(
+        job_func=run_threaded,
+        target=cache_data
+    )
 
     run_threaded(target=schedule_loop, daemon=True)  # start the schedule loop in a thread


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
When `bool_auto_update_items` was disabled, it would prevent the UI cache from being scheduled.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
