### PR TITLE
ci: use prerelease logic

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,26 +10,16 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
 
 jobs:
   setup_release:
     name: Setup Release
     outputs:
-      changelog_changes: ${{ steps.setup_release.outputs.changelog_changes }}
-      changelog_date: ${{ steps.setup_release.outputs.changelog_date }}
-      changelog_exists: ${{ steps.setup_release.outputs.changelog_exists }}
-      changelog_release_exists: ${{ steps.setup_release.outputs.changelog_release_exists }}
-      changelog_url: ${{ steps.setup_release.outputs.changelog_url }}
-      changelog_version: ${{ steps.setup_release.outputs.changelog_version }}
-      publish_pre_release: ${{ steps.setup_release.outputs.publish_pre_release }}
       publish_release: ${{ steps.setup_release.outputs.publish_release }}
-      publish_stable_release: ${{ steps.setup_release.outputs.publish_stable_release }}
-      release_body: ${{ steps.setup_release.outputs.release_body }}
       release_build: ${{ steps.setup_release.outputs.release_build }}
       release_commit: ${{ steps.setup_release.outputs.release_commit }}
-      release_generate_release_notes: ${{ steps.setup_release.outputs.release_generate_release_notes }}
       release_tag: ${{ steps.setup_release.outputs.release_tag }}
       release_version: ${{ steps.setup_release.outputs.release_version }}
     runs-on: ubuntu-latest
@@ -39,7 +29,7 @@ jobs:
 
       - name: Setup Release
         id: setup_release
-        uses: LizardByte/setup-release-action@v2024.202.205234
+        uses: LizardByte/setup-release-action@v2024.520.193857
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -131,7 +121,7 @@ jobs:
           mv ./Themerr-plex.bundle.zip ./artifacts/
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Themerr-plex.bundle
           if-no-files-found: error  # 'warn' or 'ignore' are also available, defaults to `warn`
@@ -140,14 +130,13 @@ jobs:
 
       - name: Create/Update GitHub Release
         if: ${{ needs.setup_release.outputs.publish_release == 'true' }}
-        uses: LizardByte/create-release-action@v2023.1219.224026
+        uses: LizardByte/create-release-action@v2024.520.193838
         with:
           allowUpdates: true
-          body: ''
           discussionCategory: announcements
           generateReleaseNotes: true
           name: ${{ needs.setup_release.outputs.release_tag }}
-          prerelease: ${{ needs.setup_release.outputs.publish_pre_release }}
+          prerelease: true
           tag: ${{ needs.setup_release.outputs.release_tag }}
           token: ${{ secrets.GH_BOT_TOKEN }}
 
@@ -164,7 +153,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: Themerr-plex.bundle
 
@@ -189,7 +178,7 @@ jobs:
         env:
           PLEXAPI_PLEXAPI_TIMEOUT: "60"
         id: bootstrap
-        uses: LizardByte/plexhints@v2024.229.193202
+        uses: LizardByte/plexhints@v2024.521.1558
         with:
           additional_server_queries: >-
             put|/system/agents/com.plexapp.agents.imdb/config/1?order=com.plexapp.agents.imdb%2Cdev.lizardbyte.themerr-plex
@@ -207,7 +196,8 @@ jobs:
         run: |
           python -m pip --no-python-version-warning --disable-pip-version-check install --upgrade \
             pip setuptools wheel
-          python -m pip --no-python-version-warning --disable-pip-version-check install -r requirements-dev.txt
+          python -m pip --no-python-version-warning --disable-pip-version-check install --no-build-isolation \
+            -r requirements-dev.txt
 
       - name: Test with pytest
         env:

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -29,7 +29,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
 
 jobs:
@@ -74,9 +74,27 @@ jobs:
           echo $matrix | jq .
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
+      - name: Find dotnet solution file
+        id: find_dotnet
+        run: |
+          solution=$(find . -maxdepth 1 -type f -iname "*.sln")
+
+          echo "found solution: ${solution}"
+
+          # do not quote to keep this as a single line
+          echo solution=${solution} >> $GITHUB_OUTPUT
+
+          if [[ $solution != "" ]]; then
+            echo "dotnet=true" >> $GITHUB_OUTPUT
+          else
+            echo "dotnet=false" >> $GITHUB_OUTPUT
+          fi
+
     outputs:
       dockerfiles: ${{ steps.find.outputs.dockerfiles }}
       matrix: ${{ steps.find.outputs.matrix }}
+      dotnet: ${{ steps.find_dotnet.outputs.dotnet }}
+      solution: ${{ steps.find_dotnet.outputs.solution }}
 
   setup_release:
     if: ${{ needs.check_dockerfiles.outputs.dockerfiles }}
@@ -84,19 +102,9 @@ jobs:
     needs:
       - check_dockerfiles
     outputs:
-      changelog_changes: ${{ steps.setup_release.outputs.changelog_changes }}
-      changelog_date: ${{ steps.setup_release.outputs.changelog_date }}
-      changelog_exists: ${{ steps.setup_release.outputs.changelog_exists }}
-      changelog_release_exists: ${{ steps.setup_release.outputs.changelog_release_exists }}
-      changelog_url: ${{ steps.setup_release.outputs.changelog_url }}
-      changelog_version: ${{ steps.setup_release.outputs.changelog_version }}
-      publish_pre_release: ${{ steps.setup_release.outputs.publish_pre_release }}
       publish_release: ${{ steps.setup_release.outputs.publish_release }}
-      publish_stable_release: ${{ steps.setup_release.outputs.publish_stable_release }}
-      release_body: ${{ steps.setup_release.outputs.release_body }}
       release_build: ${{ steps.setup_release.outputs.release_build }}
       release_commit: ${{ steps.setup_release.outputs.release_commit }}
-      release_generate_release_notes: ${{ steps.setup_release.outputs.release_generate_release_notes }}
       release_tag: ${{ steps.setup_release.outputs.release_tag }}
       release_version: ${{ steps.setup_release.outputs.release_version }}
     runs-on: ubuntu-latest
@@ -106,8 +114,9 @@ jobs:
 
       - name: Setup Release
         id: setup_release
-        uses: LizardByte/setup-release-action@v2024.202.205234
+        uses: LizardByte/setup-release-action@v2024.520.181643
         with:
+          dotnet: ${{ needs.check_dockerfiles.outputs.dotnet }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
   lint_dockerfile:
@@ -152,7 +161,7 @@ jobs:
 
     steps:
       - name: Maximize build space
-        uses: easimon/maximize-build-space@v8
+        uses: easimon/maximize-build-space@v10
         with:
           root-reserve-mb: 30720  # https://github.com/easimon/maximize-build-space#caveats
           remove-dotnet: 'true'
@@ -268,7 +277,7 @@ jobs:
         id: buildx
 
       - name: Cache Docker Layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: Docker-buildx${{ matrix.tag }}-${{ github.sha }}
@@ -347,28 +356,27 @@ jobs:
 
       - name: Upload Artifacts
         if: ${{ steps.prepare.outputs.artifacts == 'true' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Docker${{ matrix.tag }}
           path: artifacts/
 
       - name: Create/Update GitHub Release
         if: ${{ needs.setup_release.outputs.publish_release == 'true' && steps.prepare.outputs.artifacts == 'true' }}
-        uses: LizardByte/create-release-action@v2023.1219.224026
+        uses: LizardByte/create-release-action@v2024.520.180003
         with:
           allowUpdates: true
           artifacts: "*artifacts/*"
-          body: ''
           discussionCategory: announcements
           generateReleaseNotes: true
           name: ${{ needs.setup_release.outputs.release_tag }}
-          prerelease: ${{ needs.setup_release.outputs.publish_pre_release }}
+          prerelease: true
           tag: ${{ needs.setup_release.outputs.release_tag }}
           token: ${{ secrets.GH_BOT_TOKEN }}
 
       - name: Update Docker Hub Description
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-        uses: peter-evans/dockerhub-description@v3
+        uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}  # token is not currently supported


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- Use new prerelease logic.
- Bump plexhints action.
- Use `--no-build-isolation` to install pyyaml.
- Bump upload-artifact and download-artifact to v4.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
