### PR TITLE
ci(coverage): move coverage upload to separate job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -231,14 +231,50 @@ jobs:
           fi
           cat "${log_file}"
 
-      - name: Upload coverage
-        # any except canceled or skipped
+      - name: Upload coverage artifact
         if: >-
           always() &&
-          (steps.test.outcome == 'success' || steps.test.outcome == 'failure') &&
-          startsWith(github.repository, 'LizardByte/')
+          (steps.test.outcome == 'success' || steps.test.outcome == 'failure')
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.os }}
+          path: .coverage
+
+  coverage:
+    if: >-
+      always() &&
+      (needs.pytest.result == 'success' || needs.pytest.result == 'failure') &&
+      startsWith(github.repository, 'LizardByte/')
+    name: Coverage-${{ matrix.flag }}
+    needs: pytest
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - build_os: ubuntu-latest
+            flag: Linux
+          - build_os: macos-latest
+            flag: macOS
+          - build_os: windows-latest
+            flag: Windows
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-${{ matrix.build_os }}
+          path: _coverage
+
+      - name: Upload coverage
         uses: codecov/codecov-action@v4
         with:
+          disable_search: true
           fail_ci_if_error: true
-          flags: ${{ runner.os }}
+          files: ./_coverage/.coverage
+          flags: ${{ matrix.flag }}
           token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Moves coverage upload to separate job.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
